### PR TITLE
Added `LibraryCharges` for monatomic ions in 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ Force fields moving forward will be called `name-X.Y.Z`
 
 
 ## Versions
+- `v1.0.0 Parsley` : First major forcefield release.
 
-`v1.1.0 Parsley `: This minor release contains following changes. (1) Addition of new proper torsions and improper torsions for tetrazole; (2) Corrections to N-N bond rotation periodicity; (3) Removal of redundant periodicity component in `t19`; (4) Addition of three new bond and angle terms, `a22a`, `b14a` and `b36a`.
+    - `v1.0.1 Parsley `: This bugfix release contains following changes: (1) Addition of monatomic ion `LibraryCharges`.
+
+- `v1.1.0 Parsley `: This minor release contains following changes: (1) Addition of new proper torsions and improper torsions for tetrazole; (2) Corrections to N-N bond rotation periodicity; (3) Removal of redundant periodicity component in `t19`; (4) Addition of three new bond and angle terms, `a22a`, `b14a` and `b36a`.
 
 ## Contributors
 

--- a/openforcefields/offxml/openff-1.0.1.offxml
+++ b/openforcefields/offxml/openff-1.0.1.offxml
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <!-- This is the initial "Parsley" force field released by the Open Force Field Initiative. -->
+    <!-- The Parsley force field is available with and without bond constraints to hydrogen. -->
+    <!-- This file contains bond constraints to hydrogen, and is suitable for long-timestep simulations. -->
+	<Author>The Open Force Field Initiative</Author>
+	<Date>2019-10-10</Date>
+	<Constraints version="0.3">
+	    <!-- constrain all bonds to hydrogen to their equilibrium bond length -->
+		<Constraint smirks="[#1:1]-[*:2]" id="c1"></Constraint>
+	</Constraints>
+	<Bonds version="0.3" potential="harmonic" fractional_bondorder_method="None" fractional_bondorder_interpolation="linear">
+		<Bond smirks="[#6X4:1]-[#6X4:2]" length="1.520375903275 * angstrom" k="531.137373861 * angstrom**-2 * mole**-1 * kilocalorie" id="b1"></Bond>
+		<Bond smirks="[#6X4:1]-[#6X3:2]" length="1.503004231651 * angstrom" k="612.5097961064 * angstrom**-2 * mole**-1 * kilocalorie" id="b2"></Bond>
+		<Bond smirks="[#6X4:1]-[#6X3:2]=[#8X1+0]" length="1.521605984526 * angstrom" k="612.0537081219 * angstrom**-2 * mole**-1 * kilocalorie" id="b3"></Bond>
+		<Bond smirks="[#6X3:1]-[#6X3:2]" length="1.459752099251 * angstrom" k="568.1471787335 * angstrom**-2 * mole**-1 * kilocalorie" id="b4"></Bond>
+		<Bond smirks="[#6X3:1]:[#6X3:2]" length="1.388664968947 * angstrom" k="703.9196442458 * angstrom**-2 * mole**-1 * kilocalorie" id="b5"></Bond>
+		<Bond smirks="[#6X3:1]=[#6X3:2]" length="1.372337637107 * angstrom" k="857.1115548611 * angstrom**-2 * mole**-1 * kilocalorie" id="b6"></Bond>
+		<Bond smirks="[#6:1]-[#7:2]" length="1.465648155674 * angstrom" k="719.6326854584 * angstrom**-2 * mole**-1 * kilocalorie" id="b7"></Bond>
+		<Bond smirks="[#6X3:1]-[#7X3:2]" length="1.387166824415 * angstrom" k="719.219372554 * angstrom**-2 * mole**-1 * kilocalorie" id="b8"></Bond>
+		<Bond smirks="[#6X4:1]-[#7X3:2]-[#6X3]=[#8X1+0]" length="1.442186178076 * angstrom" k="764.7120801727 * angstrom**-2 * mole**-1 * kilocalorie" id="b9"></Bond>
+		<Bond smirks="[#6X3:1](=[#8X1+0])-[#7X3:2]" length="1.375176351196 * angstrom" k="1053.970761594 * angstrom**-2 * mole**-1 * kilocalorie" id="b10"></Bond>
+		<Bond smirks="[#6X3:1]-[#7X2:2]" length="1.374709480195 * angstrom" k="837.2647972972 * angstrom**-2 * mole**-1 * kilocalorie" id="b11"></Bond>
+		<Bond smirks="[#6X3:1]:[#7X2,#7X3+1:2]" length="1.325255477593 * angstrom" k="848.5474509553 * angstrom**-2 * mole**-1 * kilocalorie" id="b12"></Bond>
+		<Bond smirks="[#6X3:1]=[#7X2,#7X3+1:2]" length="1.315234804241 * angstrom" k="882.4191878243 * angstrom**-2 * mole**-1 * kilocalorie" id="b13"></Bond>
+		<Bond smirks="[#6:1]-[#8:2]" length="1.414287924481 * angstrom" k="669.1415170138 * angstrom**-2 * mole**-1 * kilocalorie" id="b14"></Bond>
+		<Bond smirks="[#6X4:1]-[#8X2H0:2]" length="1.426488233342 * angstrom" k="773.0316724808 * angstrom**-2 * mole**-1 * kilocalorie" id="b15"></Bond>
+		<Bond smirks="[#6X3:1]-[#8X2:2]" length="1.355290880386 * angstrom" k="636.8285821663 * angstrom**-2 * mole**-1 * kilocalorie" id="b16"></Bond>
+		<Bond smirks="[#6X3:1]-[#8X2H1:2]" length="1.367594686257 * angstrom" k="875.4107624763 * angstrom**-2 * mole**-1 * kilocalorie" id="b17"></Bond>
+		<Bond smirks="[#6X3a:1]-[#8X2H0:2]" length="1.386623123464 * angstrom" k="814.7919342234 * angstrom**-2 * mole**-1 * kilocalorie" id="b18"></Bond>
+		<Bond smirks="[#6X3:1](=[#8X1])-[#8X2H0:2]" length="1.338559054373 * angstrom" k="611.4736852721 * angstrom**-2 * mole**-1 * kilocalorie" id="b19"></Bond>
+		<Bond smirks="[#6:1]=[#8X1+0,#8X2+1:2]" length="1.22768286085 * angstrom" k="1135.595318618 * angstrom**-2 * mole**-1 * kilocalorie" id="b20"></Bond>
+		<Bond smirks="[#6X3:1](~[#8X1])~[#8X1:2]" length="1.259500720071 * angstrom" k="1226.156681261 * angstrom**-2 * mole**-1 * kilocalorie" id="b21"></Bond>
+		<Bond smirks="[#6X3:1]~[#8X2+1:2]~[#6X3]" length="1.339634537178 * angstrom" k="1121.691574284 * angstrom**-2 * mole**-1 * kilocalorie" id="b22"></Bond>
+		<Bond smirks="[#6X2:1]-[#6:2]" length="1.439319134757 * angstrom" k="729.6661176606 * angstrom**-2 * mole**-1 * kilocalorie" id="b23"></Bond>
+		<Bond smirks="[#6X2:1]-[#6X4:2]" length="1.452070257372 * angstrom" k="776.2033045699 * angstrom**-2 * mole**-1 * kilocalorie" id="b24"></Bond>
+		<Bond smirks="[#6X2:1]=[#6X3:2]" length="1.32265860193 * angstrom" k="1126.019190271 * angstrom**-2 * mole**-1 * kilocalorie" id="b25"></Bond>
+		<Bond smirks="[#6:1]#[#7:2]" length="1.173615721934 * angstrom" k="782.0438380706 * angstrom**-2 * mole**-1 * kilocalorie" id="b26"></Bond>
+		<Bond smirks="[#6X2:1]#[#6X2:2]" length="1.216289425279 * angstrom" k="728.7151236895 * angstrom**-2 * mole**-1 * kilocalorie" id="b27"></Bond>
+		<Bond smirks="[#6X2:1]-[#8X2:2]" length="1.338505557335 * angstrom" k="737.0214463026 * angstrom**-2 * mole**-1 * kilocalorie" id="b28"></Bond>
+		<Bond smirks="[#6X2:1]-[#7:2]" length="1.343265592592 * angstrom" k="926.2217362126 * angstrom**-2 * mole**-1 * kilocalorie" id="b29"></Bond>
+		<Bond smirks="[#6X2:1]=[#7:2]" length="1.19497018523 * angstrom" k="915.3902453154 * angstrom**-2 * mole**-1 * kilocalorie" id="b30"></Bond>
+		<Bond smirks="[#16:1]=[#6:2]" length="1.695948094419 * angstrom" k="606.5161612099 * angstrom**-2 * mole**-1 * kilocalorie" id="b31a"></Bond>
+		<Bond smirks="[#6X2:1]=[#16:2]" length="1.583084701849 * angstrom" k="874.5352668762 * angstrom**-2 * mole**-1 * kilocalorie" id="b31"></Bond>
+		<Bond smirks="[#7:1]-[#7:2]" length="1.456427148228 * angstrom" k="856.3884876222 * angstrom**-2 * mole**-1 * kilocalorie" id="b32"></Bond>
+		<Bond smirks="[#7X3:1]-[#7X2:2]" length="1.336997136683 * angstrom" k="721.2583300948 * angstrom**-2 * mole**-1 * kilocalorie" id="b33"></Bond>
+		<Bond smirks="[#7X2:1]-[#7X2:2]" length="1.334711243126 * angstrom" k="684.6186062369 * angstrom**-2 * mole**-1 * kilocalorie" id="b34"></Bond>
+		<Bond smirks="[#7:1]:[#7:2]" length="1.309910760379 * angstrom" k="698.9386390879 * angstrom**-2 * mole**-1 * kilocalorie" id="b35"></Bond>
+		<Bond smirks="[#7:1]=[#7:2]" length="1.258230502017 * angstrom" k="733.7063583316 * angstrom**-2 * mole**-1 * kilocalorie" id="b36"></Bond>
+		<Bond smirks="[#7:1]#[#7:2]" length="1.167045703639 * angstrom" k="768.2515008465 * angstrom**-2 * mole**-1 * kilocalorie" id="b37"></Bond>
+		<Bond smirks="[#7:1]-[#8X2:2]" length="1.427444600619 * angstrom" k="609.6331726762 * angstrom**-2 * mole**-1 * kilocalorie" id="b38"></Bond>
+		<Bond smirks="[#7:1]~[#8X1:2]" length="1.258536604727 * angstrom" k="804.2141054566 * angstrom**-2 * mole**-1 * kilocalorie" id="b39"></Bond>
+		<Bond smirks="[#8X2:1]-[#8X2:2]" length="1.446833791864 * angstrom" k="598.1110360445 * angstrom**-2 * mole**-1 * kilocalorie" id="b40"></Bond>
+		<Bond smirks="[#16:1]-[#6:2]" length="1.81 * angstrom" k="474.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b41"></Bond>
+		<Bond smirks="[#16:1]-[#1:2]" length="1.324549474701 * angstrom" k="583.3742749411 * angstrom**-2 * mole**-1 * kilocalorie" id="b42"></Bond>
+		<Bond smirks="[#16:1]-[#16:2]" length="2.081686035078 * angstrom" k="318.4060340666 * angstrom**-2 * mole**-1 * kilocalorie" id="b43"></Bond>
+		<Bond smirks="[#16:1]-[#9:2]" length="1.6 * angstrom" k="750.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b44"></Bond>
+		<Bond smirks="[#16:1]-[#17:2]" length="2.094110046685 * angstrom" k="419.5765860777 * angstrom**-2 * mole**-1 * kilocalorie" id="b45"></Bond>
+		<Bond smirks="[#16:1]-[#35:2]" length="2.237744050073 * angstrom" k="336.4025371784 * angstrom**-2 * mole**-1 * kilocalorie" id="b46"></Bond>
+		<Bond smirks="[#16:1]-[#53:2]" length="2.6 * angstrom" k="150.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b47"></Bond>
+		<Bond smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X4:2]" length="1.829210526082 * angstrom" k="415.2751791003 * angstrom**-2 * mole**-1 * kilocalorie" id="b48"></Bond>
+		<Bond smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]" length="1.762588405073 * angstrom" k="548.2622260123 * angstrom**-2 * mole**-1 * kilocalorie" id="b49"></Bond>
+		<Bond smirks="[#16X2:1]-[#7:2]" length="1.729944910038 * angstrom" k="626.0211477833 * angstrom**-2 * mole**-1 * kilocalorie" id="b50"></Bond>
+		<Bond smirks="[#16X2:1]-[#8X2:2]" length="1.674222096904 * angstrom" k="545.9813102907 * angstrom**-2 * mole**-1 * kilocalorie" id="b51"></Bond>
+		<Bond smirks="[#16X2:1]=[#8X1,#7X2:2]" length="1.492440425396 * angstrom" k="608.7780870561 * angstrom**-2 * mole**-1 * kilocalorie" id="b52"></Bond>
+		<Bond smirks="[#16X4,#16X3!+1:1]-[#6:2]" length="1.82526511478 * angstrom" k="490.9750761558 * angstrom**-2 * mole**-1 * kilocalorie" id="b53"></Bond>
+		<Bond smirks="[#16X4,#16X3:1]~[#7:2]" length="1.74923391533 * angstrom" k="532.2740756485 * angstrom**-2 * mole**-1 * kilocalorie" id="b54"></Bond>
+		<Bond smirks="[#16X4,#16X3:1]-[#8X2:2]" length="1.705021255726 * angstrom" k="586.8193418268 * angstrom**-2 * mole**-1 * kilocalorie" id="b55"></Bond>
+		<Bond smirks="[#16X4,#16X3:1]~[#8X1:2]" length="1.476709899089 * angstrom" k="988.5263278679 * angstrom**-2 * mole**-1 * kilocalorie" id="b56"></Bond>
+		<Bond smirks="[#15:1]-[#1:2]" length="1.425620548319 * angstrom" k="475.8196836784 * angstrom**-2 * mole**-1 * kilocalorie" id="b58"></Bond>
+		<Bond smirks="[#15:1]~[#6:2]" length="1.820098467465 * angstrom" k="334.797260159 * angstrom**-2 * mole**-1 * kilocalorie" id="b59"></Bond>
+		<Bond smirks="[#15:1]-[#7:2]" length="1.738963612742 * angstrom" k="649.438242264 * angstrom**-2 * mole**-1 * kilocalorie" id="b60"></Bond>
+		<Bond smirks="[#15:1]=[#7:2]" length="1.607645772515 * angstrom" k="813.0616253008 * angstrom**-2 * mole**-1 * kilocalorie" id="b61"></Bond>
+		<Bond smirks="[#15:1]~[#8X2:2]" length="1.629136766264 * angstrom" k="492.3953020799 * angstrom**-2 * mole**-1 * kilocalorie" id="b62"></Bond>
+		<Bond smirks="[#15:1]~[#8X1:2]" length="1.492571787842 * angstrom" k="1128.459872581 * angstrom**-2 * mole**-1 * kilocalorie" id="b63"></Bond>
+		<Bond smirks="[#16:1]-[#15:2]" length="2.132598077518 * angstrom" k="303.5029002242 * angstrom**-2 * mole**-1 * kilocalorie" id="b65"></Bond>
+		<Bond smirks="[#15:1]=[#16X1:2]" length="1.961822956943 * angstrom" k="463.9165708413 * angstrom**-2 * mole**-1 * kilocalorie" id="b66"></Bond>
+		<Bond smirks="[#6:1]-[#9:2]" length="1.357188255231 * angstrom" k="771.2895584699 * angstrom**-2 * mole**-1 * kilocalorie" id="b67"></Bond>
+		<Bond smirks="[#6X4:1]-[#9:2]" length="1.360066836665 * angstrom" k="739.1286982085 * angstrom**-2 * mole**-1 * kilocalorie" id="b68"></Bond>
+		<Bond smirks="[#6:1]-[#17:2]" length="1.755619464273 * angstrom" k="397.6612674232 * angstrom**-2 * mole**-1 * kilocalorie" id="b69"></Bond>
+		<Bond smirks="[#6X4:1]-[#17:2]" length="1.794826174177 * angstrom" k="415.5952215538 * angstrom**-2 * mole**-1 * kilocalorie" id="b70"></Bond>
+		<Bond smirks="[#6:1]-[#35:2]" length="1.8919521291 * angstrom" k="341.814550321 * angstrom**-2 * mole**-1 * kilocalorie" id="b71"></Bond>
+		<Bond smirks="[#6X4:1]-[#35:2]" length="1.962281793838 * angstrom" k="371.0571720485 * angstrom**-2 * mole**-1 * kilocalorie" id="b72"></Bond>
+		<Bond smirks="[#6:1]-[#53:2]" length="2.180863120343 * angstrom" k="345.9312229715 * angstrom**-2 * mole**-1 * kilocalorie" id="b73"></Bond>
+		<Bond smirks="[#6X4:1]-[#53:2]" length="2.166 * angstrom" k="296.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b74"></Bond>
+		<Bond smirks="[#7:1]-[#9:2]" length="1.437374377723 * angstrom" k="294.3868210844 * angstrom**-2 * mole**-1 * kilocalorie" id="b75"></Bond>
+		<Bond smirks="[#7:1]-[#17:2]" length="1.794539502537 * angstrom" k="294.602035553 * angstrom**-2 * mole**-1 * kilocalorie" id="b76"></Bond>
+		<Bond smirks="[#7:1]-[#35:2]" length="1.923890882292 * angstrom" k="203.8621603045 * angstrom**-2 * mole**-1 * kilocalorie" id="b77"></Bond>
+		<Bond smirks="[#7:1]-[#53:2]" length="2.1 * angstrom" k="160.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b78"></Bond>
+		<Bond smirks="[#15:1]-[#9:2]" length="1.64 * angstrom" k="880.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b79"></Bond>
+		<Bond smirks="[#15:1]-[#17:2]" length="2.040421255642 * angstrom" k="329.1717843591 * angstrom**-2 * mole**-1 * kilocalorie" id="b80"></Bond>
+		<Bond smirks="[#15:1]-[#35:2]" length="2.240634354523 * angstrom" k="249.9731712665 * angstrom**-2 * mole**-1 * kilocalorie" id="b81"></Bond>
+		<Bond smirks="[#15:1]-[#53:2]" length="2.6 * angstrom" k="140.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b82"></Bond>
+		<Bond smirks="[#6X4:1]-[#1:2]" length="1.092888378383 * angstrom" k="758.0931772913 * angstrom**-2 * mole**-1 * kilocalorie" id="b83"></Bond>
+		<Bond smirks="[#6X3:1]-[#1:2]" length="1.08506612939 * angstrom" k="808.1394472833 * angstrom**-2 * mole**-1 * kilocalorie" id="b84"></Bond>
+		<Bond smirks="[#6X2:1]-[#1:2]" length="1.0675780086 * angstrom" k="886.8140078234 * angstrom**-2 * mole**-1 * kilocalorie" id="b85"></Bond>
+		<Bond smirks="[#7:1]-[#1:2]" length="1.021370282176 * angstrom" k="997.7547006218 * angstrom**-2 * mole**-1 * kilocalorie" id="b86"></Bond>
+		<Bond smirks="[#8:1]-[#1:2]" length="0.9707687589944 * angstrom" k="1120.583236119 * angstrom**-2 * mole**-1 * kilocalorie" id="b87"></Bond>
+	</Bonds>
+	<Angles version="0.3" potential="harmonic">
+		<Angle smirks="[*:1]~[#6X4:2]-[*:3]" angle="107.6607821752 * degree" k="101.7373362367 * mole**-1 * radian**-2 * kilocalorie" id="a1"></Angle>
+		<Angle smirks="[#1:1]-[#6X4:2]-[#1:3]" angle="107.5991506326 * degree" k="74.28701527177 * mole**-1 * radian**-2 * kilocalorie" id="a2"></Angle>
+		<Angle smirks="[*;r3:1]1~;@[*;r3:2]~;@[*;r3:3]1" angle="92.01151955292 * degree" k="236.4566893088 * mole**-1 * radian**-2 * kilocalorie" id="a3"></Angle>
+		<Angle smirks="[*;r3:1]~;@[*;r3:2]~;!@[*:3]" angle="118.6397680739 * degree" k="72.98541272684 * mole**-1 * radian**-2 * kilocalorie" id="a4"></Angle>
+		<Angle smirks="[*:1]~;!@[*;r3:2]~;!@[*:3]" angle="117.2796647982 * degree" k="134.6903763341 * mole**-1 * radian**-2 * kilocalorie" id="a5"></Angle>
+		<Angle smirks="[#1:1]-[*;r3:2]~;!@[*:3]" angle="113.9117551062 * degree" k="17.45745186093 * mole**-1 * radian**-2 * kilocalorie" id="a6"></Angle>
+		<Angle smirks="[#6r4:1]-;@[#6r4:2]-;@[#6r4:3]" angle="95.89600422195 * degree" k="173.3075144443 * mole**-1 * radian**-2 * kilocalorie" id="a7"></Angle>
+		<Angle smirks="[!#1:1]-[#6r4:2]-;!@[!#1:3]" angle="120.5855863277 * degree" k="66.79578563419 * mole**-1 * radian**-2 * kilocalorie" id="a8"></Angle>
+		<Angle smirks="[!#1:1]-[#6r4:2]-;!@[#1:3]" angle="115.3485773002 * degree" k="92.53584121506 * mole**-1 * radian**-2 * kilocalorie" id="a9"></Angle>
+		<Angle smirks="[*:1]~[#6X3:2]~[*:3]" angle="132.6611914923 * degree" k="153.5899485526 * mole**-1 * radian**-2 * kilocalorie" id="a10"></Angle>
+		<Angle smirks="[#1:1]-[#6X3:2]~[*:3]" angle="138.3188636899 * degree" k="66.86418192583 * mole**-1 * radian**-2 * kilocalorie" id="a11"></Angle>
+		<Angle smirks="[#1:1]-[#6X3:2]-[#1:3]" angle="129.8919606001 * degree" k="79.05881335449 * mole**-1 * radian**-2 * kilocalorie" id="a12"></Angle>
+		<Angle smirks="[*;r6:1]~;@[*;r5:2]~;@[*;r5;x2:3]" angle="129.6186355583 * degree" k="8.393092356008 * mole**-1 * radian**-2 * kilocalorie" id="a13"></Angle>
+		<Angle smirks="[*:1]~;!@[*;X3;r5:2]~;@[*;r5:3]" angle="134.7190008471 * degree" k="70.66802196994 * mole**-1 * radian**-2 * kilocalorie" id="a14"></Angle>
+		<Angle smirks="[#8X1:1]~[#6X3:2]~[#8:3]" angle="135.0017221622 * degree" k="228.4556274517 * mole**-1 * radian**-2 * kilocalorie" id="a15"></Angle>
+		<Angle smirks="[*:1]~[#6X2:2]~[*:3]" angle="180.0 * degree" k="141.066778699 * mole**-1 * radian**-2 * kilocalorie" id="a16"></Angle>
+		<Angle smirks="[*:1]~[#7X2:2]~[*:3]" angle="180.0 * degree" k="43.86782392711 * mole**-1 * radian**-2 * kilocalorie" id="a21"></Angle>
+		<Angle smirks="[*:1]-[#7X4,#7X3,#7X2-1:2]-[*:3]" angle="115.9143430445 * degree" k="148.6973378749 * mole**-1 * radian**-2 * kilocalorie" id="a17"></Angle>
+		<Angle smirks="[#1:1]-[#7X4,#7X3,#7X2-1:2]-[*:3]" angle="113.8216708315 * degree" k="84.12106400194 * mole**-1 * radian**-2 * kilocalorie" id="a18"></Angle>
+		<Angle smirks="[*:1]~[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]~[*:3]" angle="118.7733529574 * degree" k="112.545110149 * mole**-1 * radian**-2 * kilocalorie" id="a19"></Angle>
+		<Angle smirks="[#1:1]-[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]-[*:3]" angle="122.0060844738 * degree" k="77.52610202633 * mole**-1 * radian**-2 * kilocalorie" id="a20"></Angle>
+		<Angle smirks="[*:1]~[#7X2+0:2]~[*:3]" angle="119.2677720132 * degree" k="226.9001499199 * mole**-1 * radian**-2 * kilocalorie" id="a22"></Angle>
+		<Angle smirks="[#1:1]-[#7X2+0:2]~[*:3]" angle="126.3683382039 * degree" k="122.0886574234 * mole**-1 * radian**-2 * kilocalorie" id="a23"></Angle>
+		<Angle smirks="[#6,#7,#8:1]-[#7X3:2](~[#8X1])~[#8X1:3]" angle="113.7330960918 * degree" k="222.9512331442 * mole**-1 * radian**-2 * kilocalorie" id="a24"></Angle>
+		<Angle smirks="[#8X1:1]~[#7X3:2]~[#8X1:3]" angle="129.0640146903 * degree" k="244.7497409824 * mole**-1 * radian**-2 * kilocalorie" id="a25"></Angle>
+		<Angle smirks="[*:1]~[#7X2:2]~[#7X1:3]" angle="180.0 * degree" k="85.78959792905 * mole**-1 * radian**-2 * kilocalorie" id="a26"></Angle>
+		<Angle smirks="[*:1]-[#8:2]-[*:3]" angle="110.2517797785 * degree" k="112.3648888241 * mole**-1 * radian**-2 * kilocalorie" id="a27"></Angle>
+		<Angle smirks="[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]" angle="113.749133441 * degree" k="198.6434920934 * mole**-1 * radian**-2 * kilocalorie" id="a28"></Angle>
+		<Angle smirks="[*:1]-[#8X2+1:2]=[*:3]" angle="120.6194234196 * degree" k="88.00391898891 * mole**-1 * radian**-2 * kilocalorie" id="a29"></Angle>
+		<Angle smirks="[*:1]~[#16X4:2]~[*:3]" angle="102.8533293826 * degree" k="203.9761892412 * mole**-1 * radian**-2 * kilocalorie" id="a30"></Angle>
+		<Angle smirks="[*:1]-[#16X4,#16X3+0:2]-[*:3]" angle="93.10273130442 * degree" k="148.5489471172 * mole**-1 * radian**-2 * kilocalorie" id="a31"></Angle>
+		<Angle smirks="[*:1]~[#16X3$(*~[#8X1,#7X2]):2]~[*:3]" angle="105.27918908 * degree" k="131.5701278604 * mole**-1 * radian**-2 * kilocalorie" id="a32"></Angle>
+		<Angle smirks="[*:1]~[#16X2,#16X3+1:2]~[*:3]" angle="102.5325123581 * degree" k="155.6608313033 * mole**-1 * radian**-2 * kilocalorie" id="a33"></Angle>
+		<Angle smirks="[*:1]=[#16X2:2]=[*:3]" angle="180.0 * degree" k="140.0 * mole**-1 * radian**-2 * kilocalorie" id="a34"></Angle>
+		<Angle smirks="[*:1]=[#16X2:2]=[#8:3]" angle="116.8957504594 * degree" k="135.0821099905 * mole**-1 * radian**-2 * kilocalorie" id="a34a"></Angle>
+		<Angle smirks="[#6X3:1]-[#16X2:2]-[#6X3:3]" angle="105.0921879973 * degree" k="189.8954666404 * mole**-1 * radian**-2 * kilocalorie" id="a35"></Angle>
+		<Angle smirks="[#6X3:1]-[#16X2:2]-[#6X4:3]" angle="94.39131484403 * degree" k="148.0197011788 * mole**-1 * radian**-2 * kilocalorie" id="a36"></Angle>
+		<Angle smirks="[#6X3:1]-[#16X2:2]-[#1:3]" angle="97.65567062192 * degree" k="114.2356380309 * mole**-1 * radian**-2 * kilocalorie" id="a37"></Angle>
+		<Angle smirks="[*:1]~[#15:2]~[*:3]" angle="121.7393987118 * degree" k="149.2087083994 * mole**-1 * radian**-2 * kilocalorie" id="a38"></Angle>
+	</Angles>
+	<ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))" default_idivf="auto">
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.2042684902198 * mole**-1 * kilocalorie" id="t1" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="0.0605419264413 * mole**-1 * kilocalorie" k2="0.4092110734344 * mole**-1 * kilocalorie" k3="0.4200425154529 * mole**-1 * kilocalorie" id="t2" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1044905747383 * mole**-1 * kilocalorie" id="t3" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" periodicity1="3" phase1="0.0 * degree" k1="0.106579031638 * mole**-1 * kilocalorie" id="t4" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X2:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="-0.2483367359288 * mole**-1 * kilocalorie" k2="1.128041608539 * mole**-1 * kilocalorie" id="t5" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#9:1]-[#6X4:2]-[#6X4:3]-[#9:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.09417224713276 * mole**-1 * kilocalorie" k2="0.411620155453 * mole**-1 * kilocalorie" id="t6" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#17:1]-[#6X4:2]-[#6X4:3]-[#17:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.1331743756595 * mole**-1 * kilocalorie" k2="-0.2268282090029 * mole**-1 * kilocalorie" id="t7" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#35:1]-[#6X4:2]-[#6X4:3]-[#35:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.03462841703189 * mole**-1 * kilocalorie" k2="-0.1922542771735 * mole**-1 * kilocalorie" id="t8" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.1758169817633 * mole**-1 * kilocalorie" k2="-0.4828571351304 * mole**-1 * kilocalorie" id="t9" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#9:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.1078167477482 * mole**-1 * kilocalorie" k2="0.3430106006498 * mole**-1 * kilocalorie" id="t10" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#17:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.3016855451662 * mole**-1 * kilocalorie" k2="0.1313715548727 * mole**-1 * kilocalorie" id="t11" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#35:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.2605683736706 * mole**-1 * kilocalorie" k2="0.973725680562 * mole**-1 * kilocalorie" id="t12" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X4;r3:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.007592301840152 * mole**-1 * kilocalorie" id="t13" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" phase1="0.0 * degree" k1="-0.08233024955265 * mole**-1 * kilocalorie" id="t14" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4;r3:2]-@[#6X4;r3:3]-[*:4]" periodicity1="2" phase1="0.0 * degree" k1="-1.353782897678 * mole**-1 * kilocalorie" id="t15" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-[#6X4;r3:2]-[#6X4;r3:3]-[*:4]" periodicity1="2" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="2.737380742685 * mole**-1 * kilocalorie" k2="3.956364290721 * mole**-1 * kilocalorie" id="t16" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#6X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1276594477369 * mole**-1 * kilocalorie" id="t17" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X3:3]=[*:4]" periodicity1="2" phase1="0.0 * degree" k1="-0.597427050072 * mole**-1 * kilocalorie" id="t20" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#8X1:4]" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="0.1789270699027 * mole**-1 * kilocalorie" k2="-0.04232792925765 * mole**-1 * kilocalorie" k3="-0.08746409932169 * mole**-1 * kilocalorie" id="t18" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" periodicity1="3" periodicity2="1" periodicity3="3" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="-0.1873119095899 * mole**-1 * kilocalorie" k2="-0.04978952830043 * mole**-1 * kilocalorie" k3="0.3463807083481 * mole**-1 * kilocalorie" id="t19" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.2131311610311 * mole**-1 * kilocalorie" k2="0.7627055695704 * mole**-1 * kilocalorie" id="t21" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#7X3:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" periodicity1="1" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="0.1824795050487 * mole**-1 * kilocalorie" k2="-0.3603670219594 * mole**-1 * kilocalorie" id="t22" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" periodicity1="4" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="-0.02052647057064 * mole**-1 * kilocalorie" k2="0.07928952716305 * mole**-1 * kilocalorie" id="t23" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#1:4]" periodicity1="2" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.1737641394184 * mole**-1 * kilocalorie" k2="-0.1890925901757 * mole**-1 * kilocalorie" id="t24" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X4,#7X3:4]" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="2" periodicity5="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" phase4="270.0 * degree" phase5="90.0 * degree" k1="0.1078089877718 * mole**-1 * kilocalorie" k2="0.09278468525422 * mole**-1 * kilocalorie" k3="0.9960488213521 * mole**-1 * kilocalorie" k4="0.260584803531 * mole**-1 * kilocalorie" k5="0.3136228873527 * mole**-1 * kilocalorie" id="t25" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0"></Proper>
+		<Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X3$(*-[#6X3,#6X2]):4]" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="2" periodicity5="1" periodicity6="1" phase1="270.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" phase4="270.0 * degree" phase5="270.0 * degree" phase6="0.0 * degree" k1="0.08033482806493 * mole**-1 * kilocalorie" k2="-0.137580576949 * mole**-1 * kilocalorie" k3="0.9946589743277 * mole**-1 * kilocalorie" k4="0.2268286377737 * mole**-1 * kilocalorie" k5="0.65219409882 * mole**-1 * kilocalorie" k6="-0.5193766160867 * mole**-1 * kilocalorie" id="t26" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0" idivf6="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4;r3:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.1415487720542 * mole**-1 * kilocalorie" id="t27" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.1518183405832 * mole**-1 * kilocalorie" k2="1.14870493759 * mole**-1 * kilocalorie" id="t28" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="3" periodicity3="2" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="-0.03897130741755 * mole**-1 * kilocalorie" k2="-0.333163577142 * mole**-1 * kilocalorie" k3="0.3412438908884 * mole**-1 * kilocalorie" id="t29" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]-[#7X3:4]" periodicity1="2" periodicity2="1" periodicity3="3" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="1.539412096516 * mole**-1 * kilocalorie" k2="0.5735548323954 * mole**-1 * kilocalorie" k3="0.8448125537749 * mole**-1 * kilocalorie" id="t30" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" periodicity2="1" periodicity3="3" phase1="180.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="3.301974551105 * mole**-1 * kilocalorie" k2="-0.07256453943771 * mole**-1 * kilocalorie" k3="0.04373598115894 * mole**-1 * kilocalorie" id="t31" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="2" phase1="180.0 * degree" k1="0.9065324693536 * mole**-1 * kilocalorie" id="t32" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.04786463196335 * mole**-1 * kilocalorie" k2="0.1047480522598 * mole**-1 * kilocalorie" id="t33" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="3" periodicity3="2" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="0.015950140458 * mole**-1 * kilocalorie" k2="-1.549773172362 * mole**-1 * kilocalorie" k3="0.4019718273629 * mole**-1 * kilocalorie" id="t34" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#6X3;r6:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.04348528649029 * mole**-1 * kilocalorie" k2="0.4549498533928 * mole**-1 * kilocalorie" id="t35" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]-;@[#6X3;r5:4]" periodicity1="4" periodicity2="3" periodicity3="2" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="-0.06748672800029 * mole**-1 * kilocalorie" k2="0.4937784706757 * mole**-1 * kilocalorie" k3="0.6540665434676 * mole**-1 * kilocalorie" id="t36" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]=;@[#6X3;r5:4]" periodicity1="1" phase1="180.0 * degree" k1="0.2335458170782 * mole**-1 * kilocalorie" id="t37" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#6X4:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0841836475843 * mole**-1 * kilocalorie" id="t38" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#7X2;r6:4]" periodicity1="2" periodicity2="1" periodicity3="3" phase1="180.0 * degree" phase2="180.0 * degree" phase3="0.0 * degree" k1="2.23025149902 * mole**-1 * kilocalorie" k2="-0.4960340008049 * mole**-1 * kilocalorie" k3="0.6156959282373 * mole**-1 * kilocalorie" id="t39" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#7X2:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="0.4299264955005 * mole**-1 * kilocalorie" k2="0.6769651362667 * mole**-1 * kilocalorie" k3="0.3161458831389 * mole**-1 * kilocalorie" id="t40" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#8X2:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.1813132690464 * mole**-1 * kilocalorie" k2="0.9258638279728 * mole**-1 * kilocalorie" id="t41" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" phase1="320.0 * degree" k1="-0.2715588257121 * mole**-1 * kilocalorie" id="t42" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.9155269008137 * mole**-1 * kilocalorie" id="t43" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]:[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.618818564799 * mole**-1 * kilocalorie" id="t44" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-,:[#6X3:2]=[#6X3:3]-,:[*:4]" periodicity1="2" phase1="180.0 * degree" k1="4.792759872377 * mole**-1 * kilocalorie" id="t45" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X3:2]=[#6X3:3]-[#6X4:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="180.0 * degree" k1="5.953289865563 * mole**-1 * kilocalorie" k2="1.072305796413 * mole**-1 * kilocalorie" id="t46" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#6X3$(*=[#8,#16,#7]):3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.7548786939088 * mole**-1 * kilocalorie" id="t47" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]=[#6X3:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" periodicity2="3" phase1="180.0 * degree" phase2="0.0 * degree" k1="0.7455769542514 * mole**-1 * kilocalorie" k2="0.6505987541733 * mole**-1 * kilocalorie" id="t48" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7a:2]:[#6a:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="4.593309631475 * mole**-1 * kilocalorie" id="t49" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1156981506898 * mole**-1 * kilocalorie" id="t50" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X3:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.2321691168976 * mole**-1 * kilocalorie" id="t51" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.3705879511091 * mole**-1 * kilocalorie" k2="-0.1341341034377 * mole**-1 * kilocalorie" id="t52" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.8749574048405 * mole**-1 * kilocalorie" id="t54" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="1" phase1="0.0 * degree" k1="1.008774405287 * mole**-1 * kilocalorie" id="t55" idivf1="1.0"></Proper>
+		<Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="-0.0766536570343 * mole**-1 * kilocalorie" id="t56" idivf1="1.0"></Proper>
+		<Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" phase1="0.0 * degree" k1="0.8774543263348 * mole**-1 * kilocalorie" id="t57" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X4:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="5.369347805632e-17 * mole**-1 * kilocalorie" id="t58" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" periodicity1="2" periodicity2="3" phase1="0.0 * degree" phase2="0.0 * degree" k1="-0.03305139926133 * mole**-1 * kilocalorie" k2="-0.05536205135587 * mole**-1 * kilocalorie" id="t59" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#8X1]):3]~[#8X1:4]" periodicity1="3" phase1="0.0 * degree" k1="8.47877793808e-18 * mole**-1 * kilocalorie" id="t60" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4:3]-[#6X3:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="0.0 * degree" k1="-0.5534139566497 * mole**-1 * kilocalorie" k2="-0.4613593740183 * mole**-1 * kilocalorie" id="t61" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]=[#8,#16,#7]" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="180.0 * degree" phase2="180.0 * degree" phase3="0.0 * degree" phase4="0.0 * degree" k1="-0.02939990984868 * mole**-1 * kilocalorie" k2="-0.131149297417 * mole**-1 * kilocalorie" k3="0.4462905163069 * mole**-1 * kilocalorie" k4="-0.5246679958425 * mole**-1 * kilocalorie" id="t62" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0"></Proper>
+		<Proper smirks="[#8X2H0:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]" periodicity1="2" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.006575461415428 * mole**-1 * kilocalorie" k2="2.5157095378 * mole**-1 * kilocalorie" id="t63" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.3445486734874 * mole**-1 * kilocalorie" k2="0.1649871217431 * mole**-1 * kilocalorie" k3="-1.195871309379 * mole**-1 * kilocalorie" id="t64" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2:2]-[#6X4:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-2.226456506206 * mole**-1 * kilocalorie" id="t65" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]=[#7X2,#7X3+1:2]-[#6X4:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.007272347748412 * mole**-1 * kilocalorie" id="t66" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]=[#7X2,#7X3+1:2]-[#6X4:3]-[#6X3,#6X4:4]" periodicity1="1" phase1="0.0 * degree" k1="1.115243623002 * mole**-1 * kilocalorie" id="t67" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3,#7X2-1:2]-[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.718745996216 * mole**-1 * kilocalorie" id="t68" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3,#7X2-1:2]-!@[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.037917001266 * mole**-1 * kilocalorie" id="t69" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X3:2]-[#6X3:3]=[#8,#16,#7:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="0.0 * degree" k1="2.346492420144 * mole**-1 * kilocalorie" k2="1.137927495861 * mole**-1 * kilocalorie" id="t70" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3;r5:2]-@[#6X3;r5:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.884040622793 * mole**-1 * kilocalorie" id="t71" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#7X3:2]~[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.464539201002 * mole**-1 * kilocalorie" id="t72" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#7X2,#7X3+1:2]-[#6X3:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.5024838332087 * mole**-1 * kilocalorie" id="t73" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#7X2,#7X3+1:2]-[#6X3:3]=,:[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.055700307947 * mole**-1 * kilocalorie" id="t74" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2,#7X3$(*~[#8X1]):2]:[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.949161231871 * mole**-1 * kilocalorie" id="t75" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]:[#7X2:2]:[#6X3:3]:[#6X3:4]" periodicity1="2" phase1="180.0 * degree" k1="5.12882020997 * mole**-1 * kilocalorie" id="t76" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-,:[#6X3:2]=[#7X2:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="6.38706963733 * mole**-1 * kilocalorie" id="t77" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3+1:2]=,:[#6X3:3]-,:[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.259904879645 * mole**-1 * kilocalorie" id="t78" idivf1="1.0"></Proper>
+		<Proper smirks="[#16X4,#16X3+0:1]-[#7X2:2]=[#6X3:3]-[#7X3:4]" periodicity1="2" phase1="180.0 * degree" k1="7.449362724034 * mole**-1 * kilocalorie" id="t79" idivf1="1.0"></Proper>
+		<Proper smirks="[#16X4,#16X3+0:1]-[#7X2:2]=[#6X3:3]-[#16X2,#16X3+1:4]" periodicity1="2" phase1="180.0 * degree" k1="7.44794573622 * mole**-1 * kilocalorie" id="t80" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X2:1]~[#7X2:2]-[#6X3:3]~[#6X3:4]" periodicity1="2" phase1="180.0 * degree" k1="0.7894608447333 * mole**-1 * kilocalorie" id="t81" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X2:1]~[#7X2:2]-[#6X4:3]-[#6X3:4]" periodicity1="2" phase1="0.0 * degree" k1="0.1682002924899 * mole**-1 * kilocalorie" id="t82" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X2:1]~[#7X2:2]-[#6X4:3]~[#1:4]" periodicity1="2" phase1="0.0 * degree" k1="0.2066690085515 * mole**-1 * kilocalorie" id="t83" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#8X2:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.677754035886 * mole**-1 * kilocalorie" id="t84" idivf1="3.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H1:3]-[#1:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.6200339965628 * mole**-1 * kilocalorie" k2="0.1559715289248 * mole**-1 * kilocalorie" id="t85" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#8X2H0:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.6487471201911 * mole**-1 * kilocalorie" id="t86" idivf1="3.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H0:3]-[#6X4:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.1201602570929 * mole**-1 * kilocalorie" k2="0.2551246630369 * mole**-1 * kilocalorie" id="t87" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2:3]-[#6X3:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.3142475958047 * mole**-1 * kilocalorie" k2="0.4833474029957 * mole**-1 * kilocalorie" id="t88" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#8X2:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="0.3764539115662 * mole**-1 * kilocalorie" k2="0.1665998701278 * mole**-1 * kilocalorie" k3="1.002451174967 * mole**-1 * kilocalorie" id="t89" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#7X3:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.4733717929385 * mole**-1 * kilocalorie" k2="0.6188926485362 * mole**-1 * kilocalorie" id="t90" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#8X2:2]-[#6X4;r3:3]-@[#6X4;r3:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.2610240894789 * mole**-1 * kilocalorie" id="t91" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="0.143788943859 * mole**-1 * kilocalorie" id="t92" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.4318425069884 * mole**-1 * kilocalorie" k2="0.2319379326525 * mole**-1 * kilocalorie" k3="0.6296436621974 * mole**-1 * kilocalorie" id="t93" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.2849976154746 * mole**-1 * kilocalorie" k2="0.1292437806249 * mole**-1 * kilocalorie" k3="0.5311397361715 * mole**-1 * kilocalorie" id="t94" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.6634096149646 * mole**-1 * kilocalorie" k2="0.2633663955936 * mole**-1 * kilocalorie" k3="0.9542011283438 * mole**-1 * kilocalorie" id="t95" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#8X2:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.62929291652 * mole**-1 * kilocalorie" id="t96" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#8X2:3]-[#1:4]" periodicity1="2" phase1="180.0 * degree" k1="0.726205931984 * mole**-1 * kilocalorie" id="t97" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2](=[#8,#16,#7])-[#8X2H0:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.32811993543 * mole**-1 * kilocalorie" id="t98" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2](=[#8,#16,#7])-[#8:3]-[#1:4]" periodicity1="2" phase1="180.0 * degree" k1="2.528228854647 * mole**-1 * kilocalorie" id="t99" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="0.0 * degree" k1="2.531229040642 * mole**-1 * kilocalorie" k2="1.828202607366 * mole**-1 * kilocalorie" id="t100" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#8,#16,#7:1]=[#6X3:2]-[#8X2H0:3]-[#6X4:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="180.0 * degree" k1="1.625437483618 * mole**-1 * kilocalorie" k2="0.3820999993428 * mole**-1 * kilocalorie" id="t101" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2:2]@[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.435897161514 * mole**-1 * kilocalorie" id="t102" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2+1:2]=[#6X3:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="3.0 * mole**-1 * kilocalorie" id="t103" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#8X2+1:2]-[#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.4092140738685 * mole**-1 * kilocalorie" id="t104" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16:2]=,:[#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="3.592416344286 * mole**-1 * kilocalorie" id="t105" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.5219870587066 * mole**-1 * kilocalorie" id="t106" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#6:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1391610838139 * mole**-1 * kilocalorie" id="t107" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-@[#16X2,#16X1-1,#16X3+1:2]-@[#6X3,#7X2;r5:3]=@[#6,#7;r5:4]" periodicity1="2" phase1="180.0 * degree" k1="2.208938525658 * mole**-1 * kilocalorie" id="t108" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3!+1:2]-[#6X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1136478469136 * mole**-1 * kilocalorie" id="t109" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#6X4:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.1387264656602 * mole**-1 * kilocalorie" id="t110" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#6X4:3]~[#6X4:4]" periodicity1="3" phase1="0.0 * degree" k1="0.5135725027276 * mole**-1 * kilocalorie" id="t111" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.3496146350028 * mole**-1 * kilocalorie" id="t112" idivf1="1.0"></Proper>
+		<Proper smirks="[#6:1]-[#16X4,#16X3+0:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.7795199683341 * mole**-1 * kilocalorie" id="t113" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#15:2]-[#6:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.002443571718831 * mole**-1 * kilocalorie" id="t114" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#15:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.001992367425 * mole**-1 * kilocalorie" id="t115" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8:2]-[#8:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.5445220416871 * mole**-1 * kilocalorie" id="t116" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8:2]-[#8H1:3]-[*:4]" periodicity1="2" phase1="0.0 * degree" k1="0.3326104723068 * mole**-1 * kilocalorie" id="t117" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#8X2:2]-[#7:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.8307280524112 * mole**-1 * kilocalorie" id="t118" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2r5:2]-;@[#7X3r5:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.5286479506 * mole**-1 * kilocalorie" id="t119" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2r5:2]-;@[#7X2r5:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.05933872376973 * mole**-1 * kilocalorie" id="t120" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.8534757709034 * mole**-1 * kilocalorie" id="t121" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.1975054585575 * mole**-1 * kilocalorie" k2="0.6241848836363 * mole**-1 * kilocalorie" k3="0.2694152338654 * mole**-1 * kilocalorie" id="t122" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.4212085878484 * mole**-1 * kilocalorie" k2="0.8879036298101 * mole**-1 * kilocalorie" k3="0.688629271769 * mole**-1 * kilocalorie" id="t123" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.8335579151882 * mole**-1 * kilocalorie" k2="1.129486608751 * mole**-1 * kilocalorie" k3="2.143594528019 * mole**-1 * kilocalorie" id="t124" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X4,#7X3:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.03344675530247 * mole**-1 * kilocalorie" id="t125" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3$(*-[#6X3,#6X2]):2]-[#7X3$(*-[#6X3,#6X2]):3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.1391875487532 * mole**-1 * kilocalorie" id="t126" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3$(*-[#6X3,#6X2])r5:2]-@[#7X3$(*-[#6X3,#6X2])r5:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="-1.065249127933 * mole**-1 * kilocalorie" id="t127" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]@[#7X2:2]@[#7X2:3]@[#7X2,#6X3:4]" periodicity1="1" phase1="180.0 * degree" k1="0.2079570107704 * mole**-1 * kilocalorie" id="t128a" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2:2]-[#7X3:3]~[*:4]" periodicity1="1" phase1="180.0 * degree" k1="0.8514968744526 * mole**-1 * kilocalorie" id="t128" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#7X2:2]-[#7X2:3]=[*:4]" periodicity1="1" phase1="180.0 * degree" k1="1.499767373996 * mole**-1 * kilocalorie" id="t129" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2:2]=,:[#7X2:3]~[*:4]" periodicity1="1" phase1="180.0 * degree" k1="6.47740768168 * mole**-1 * kilocalorie" id="t130" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3+1:2]=,:[#7X2:3]~[*:4]" periodicity1="1" phase1="180.0 * degree" k1="3.0 * mole**-1 * kilocalorie" id="t131" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[!#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="-0.2333557358222 * mole**-1 * kilocalorie" id="t133" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#7:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.51152804307 * mole**-1 * kilocalorie" id="t134" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="-1.514362492777 * mole**-1 * kilocalorie" id="t135" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.4279493895898 * mole**-1 * kilocalorie" id="t136" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="1" periodicity2="3" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.5598961487159 * mole**-1 * kilocalorie" k2="0.6590735051956 * mole**-1 * kilocalorie" id="t137" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.3026942933012 * mole**-1 * kilocalorie" k2="1.198096905238 * mole**-1 * kilocalorie" k3="1.209851551226 * mole**-1 * kilocalorie" id="t138" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="1" periodicity2="3" phase1="180.0 * degree" phase2="0.0 * degree" k1="-0.56371143888 * mole**-1 * kilocalorie" k2="0.2537982014446 * mole**-1 * kilocalorie" id="t139" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="0.0 * degree" k1="0.2448981098593 * mole**-1 * kilocalorie" k2="0.3432197880948 * mole**-1 * kilocalorie" k3="1.920309966993 * mole**-1 * kilocalorie" id="t140" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="1.155444592591 * mole**-1 * kilocalorie" k2="1.61687424291 * mole**-1 * kilocalorie" k3="1.356197352471 * mole**-1 * kilocalorie" id="t141" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" periodicity1="3" periodicity2="2" phase1="90.0 * degree" phase2="0.0 * degree" k1="0.1346125288073 * mole**-1 * kilocalorie" k2="1.010013299443 * mole**-1 * kilocalorie" id="t142" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" periodicity1="1" phase1="0.0 * degree" k1="1.040012168564 * mole**-1 * kilocalorie" id="t143" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X3:3]-[#7X2:4]" periodicity1="1" phase1="0.0 * degree" k1="1.138731061568 * mole**-1 * kilocalorie" id="t144" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]=,:[#7X2:3]-,:[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.6019943654949 * mole**-1 * kilocalorie" id="t145" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" periodicity1="6" periodicity2="5" periodicity3="4" periodicity4="3" periodicity5="2" periodicity6="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" phase4="0.0 * degree" phase5="180.0 * degree" phase6="0.0 * degree" k1="-0.04771589627733 * mole**-1 * kilocalorie" k2="0.8282851806511 * mole**-1 * kilocalorie" k3="0.01204072937984 * mole**-1 * kilocalorie" k4="0.7629247804472 * mole**-1 * kilocalorie" k5="2.66836500636 * mole**-1 * kilocalorie" k6="1.252206277842 * mole**-1 * kilocalorie" id="t146" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0" idivf6="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" periodicity1="6" periodicity2="5" periodicity3="4" periodicity4="2" periodicity5="3" periodicity6="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" phase4="180.0 * degree" phase5="180.0 * degree" phase6="0.0 * degree" k1="-0.2168186798692 * mole**-1 * kilocalorie" k2="1.10833542158 * mole**-1 * kilocalorie" k3="0.4467277261519 * mole**-1 * kilocalorie" k4="2.411074166888 * mole**-1 * kilocalorie" k5="0.8261849640204 * mole**-1 * kilocalorie" k6="2.207300781718 * mole**-1 * kilocalorie" id="t147" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0" idivf6="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#8X2:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.345814498131 * mole**-1 * kilocalorie" id="t148" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#16X2,#16X3+1:3]-[*:4]" periodicity1="2" periodicity2="3" phase1="0.0 * degree" phase2="0.0 * degree" k1="3.529263293178 * mole**-1 * kilocalorie" k2="0.5690320037338 * mole**-1 * kilocalorie" id="t149" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2:2]-[#15:3]~[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.796737659009 * mole**-1 * kilocalorie" id="t150" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X2:1]-[#15:2]-[#8X2:3]-[#6X4:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="-1.041801197636 * mole**-1 * kilocalorie" k2="-1.125332211858 * mole**-1 * kilocalorie" id="t151" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3:2]-[#15:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.248880120783 * mole**-1 * kilocalorie" id="t152" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7:2]-[#15:3]=[*:4]" periodicity1="2" periodicity2="3" phase1="180.0 * degree" phase2="0.0 * degree" k1="3.422374057462 * mole**-1 * kilocalorie" k2="0.8329784989581 * mole**-1 * kilocalorie" id="t154" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#7:2]-[#15:3]=[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.4293930381085 * mole**-1 * kilocalorie" id="t155" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7:2]=[#15:3]~[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.3307367671149 * mole**-1 * kilocalorie" id="t155b" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[*:2]#[*:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0 * mole**-1 * kilocalorie" id="t156" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[*:2]-[*:3]#[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0 * mole**-1 * kilocalorie" id="t157" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[*:2]=[#6,#7,#16,#15;X2:3]=[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0 * mole**-1 * kilocalorie" id="t158" idivf1="1.0"></Proper>
+	</ProperTorsions>
+	<ImproperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))" default_idivf="auto">
+		<Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.1 * mole**-1 * kilocalorie" id="i1"></Improper>
+		<Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" periodicity1="2" phase1="180.0 * degree" k1="10.5 * mole**-1 * kilocalorie" id="i2"></Improper>
+		<Improper smirks="[*:1]~[#7X3$(*~[#6X3]):2](~[*:3])~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.0 * mole**-1 * kilocalorie" id="i3"></Improper>
+		<Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" periodicity1="2" phase1="180.0 * degree" k1="10.5 * mole**-1 * kilocalorie" id="i4"></Improper>
+	</ImproperTorsions>
+	<vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom" switch_width="1.0 * angstrom" method="cutoff">
+		<Atom smirks="[#1:1]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n1" rmin_half="0.6 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n2" rmin_half="1.487 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n3" rmin_half="1.387 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4](-[#7,#8,#9,#16,#17,#35])-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n4" rmin_half="1.287 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4](-[#7,#8,#9,#16,#17,#35])(-[#7,#8,#9,#16,#17,#35])-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n5" rmin_half="1.187 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4]~[*+1,*+2]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n6" rmin_half="1.1 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X3]" epsilon="0.015 * mole**-1 * kilocalorie" id="n7" rmin_half="1.459 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X3]~[#7,#8,#9,#16,#17,#35]" epsilon="0.015 * mole**-1 * kilocalorie" id="n8" rmin_half="1.409 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X3](~[#7,#8,#9,#16,#17,#35])~[#7,#8,#9,#16,#17,#35]" epsilon="0.015 * mole**-1 * kilocalorie" id="n9" rmin_half="1.359 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X2]" epsilon="0.015 * mole**-1 * kilocalorie" id="n10" rmin_half="1.459 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#7]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n11" rmin_half="0.6 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#8]" epsilon="5.27e-05 * mole**-1 * kilocalorie" id="n12" rmin_half="0.3 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#16]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n13" rmin_half="0.6 * angstrom"></Atom>
+		<Atom smirks="[#6:1]" epsilon="0.086 * mole**-1 * kilocalorie" id="n14" rmin_half="1.908 * angstrom"></Atom>
+		<Atom smirks="[#6X2:1]" epsilon="0.21 * mole**-1 * kilocalorie" id="n15" rmin_half="1.908 * angstrom"></Atom>
+		<Atom smirks="[#6X4:1]" epsilon="0.1094 * mole**-1 * kilocalorie" id="n16" rmin_half="1.908 * angstrom"></Atom>
+		<Atom smirks="[#8:1]" epsilon="0.21 * mole**-1 * kilocalorie" id="n17" rmin_half="1.6612 * angstrom"></Atom>
+		<Atom smirks="[#8X2H0+0:1]" epsilon="0.17 * mole**-1 * kilocalorie" id="n18" rmin_half="1.6837 * angstrom"></Atom>
+		<Atom smirks="[#8X2H1+0:1]" epsilon="0.2104 * mole**-1 * kilocalorie" id="n19" rmin_half="1.721 * angstrom"></Atom>
+		<Atom smirks="[#7:1]" epsilon="0.17 * mole**-1 * kilocalorie" id="n20" rmin_half="1.824 * angstrom"></Atom>
+		<Atom smirks="[#16:1]" epsilon="0.25 * mole**-1 * kilocalorie" id="n21" rmin_half="2.0 * angstrom"></Atom>
+		<Atom smirks="[#15:1]" epsilon="0.2 * mole**-1 * kilocalorie" id="n22" rmin_half="2.1 * angstrom"></Atom>
+		<Atom smirks="[#9:1]" epsilon="0.061 * mole**-1 * kilocalorie" id="n23" rmin_half="1.75 * angstrom"></Atom>
+		<Atom smirks="[#17:1]" epsilon="0.265 * mole**-1 * kilocalorie" id="n24" rmin_half="1.948 * angstrom"></Atom>
+		<Atom smirks="[#35:1]" epsilon="0.32 * mole**-1 * kilocalorie" id="n25" rmin_half="2.22 * angstrom"></Atom>
+		<Atom smirks="[#53:1]" epsilon="0.4 * mole**-1 * kilocalorie" id="n26" rmin_half="2.35 * angstrom"></Atom>
+		<Atom smirks="[#3+1:1]" epsilon="0.0279896 * mole**-1 * kilocalorie" id="n27" rmin_half="1.025 * angstrom"></Atom>
+		<Atom smirks="[#11+1:1]" epsilon="0.0874393 * mole**-1 * kilocalorie" id="n28" rmin_half="1.369 * angstrom"></Atom>
+		<Atom smirks="[#19+1:1]" epsilon="0.1936829 * mole**-1 * kilocalorie" id="n29" rmin_half="1.705 * angstrom"></Atom>
+		<Atom smirks="[#37+1:1]" epsilon="0.3278219 * mole**-1 * kilocalorie" id="n30" rmin_half="1.813 * angstrom"></Atom>
+		<Atom smirks="[#55+1:1]" epsilon="0.4065394 * mole**-1 * kilocalorie" id="n31" rmin_half="1.976 * angstrom"></Atom>
+		<Atom smirks="[#9X0-1:1]" epsilon="0.003364 * mole**-1 * kilocalorie" id="n32" rmin_half="2.303 * angstrom"></Atom>
+		<Atom smirks="[#17X0-1:1]" epsilon="0.035591 * mole**-1 * kilocalorie" id="n33" rmin_half="2.513 * angstrom"></Atom>
+		<Atom smirks="[#35X0-1:1]" epsilon="0.0586554 * mole**-1 * kilocalorie" id="n34" rmin_half="2.608 * angstrom"></Atom>
+		<Atom smirks="[#53X0-1:1]" epsilon="0.0536816 * mole**-1 * kilocalorie" id="n35" rmin_half="2.86 * angstrom"></Atom>
+	</vdW>
+	<Electrostatics version="0.3" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" cutoff="9.0 * angstrom" switch_width="0.0 * angstrom" method="PME"></Electrostatics>
+    <LibraryCharges version="0.3">
+        <LibraryCharge name="Li+" smirks="[#3+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="Na+" smirks="[#11+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="K+" smirks="[#19+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="Rb+" smirks="[#37+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="Cs+" smirks="[#55+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="F-" smirks="[#9X0-1:1]" charge1="-1.0*elementary_charge"/>
+        <LibraryCharge name="Cl-" smirks="[#17X0-1:1]" charge1="-1.0*elementary_charge"/>
+        <LibraryCharge name="Br-" smirks="[#35X0-1:1]" charge1="-1.0*elementary_charge"/>
+        <LibraryCharge name="I-" smirks="[#53X0-1:1]" charge1="-1.0*elementary_charge"/>
+    </LibraryCharges>
+	<ToolkitAM1BCC version="0.3"></ToolkitAM1BCC>
+</SMIRNOFF>

--- a/openforcefields/offxml/openff_unconstrained-1.0.1.offxml
+++ b/openforcefields/offxml/openff_unconstrained-1.0.1.offxml
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <!-- This is the initial "Parsley" force field released by the Open Force Field Initiative. -->
+    <!-- The Parsley force field is available with and without bond constraints to hydrogen. -->
+    <!-- This file does not contain bond constraints to hydrogen, and is suitable for geometry optimization and -->
+    <!-- single-point energy evaluations. "-->
+    <Author>The Open Force Field Initiative</Author>
+	<Date>2019-10-10</Date>
+	<Bonds version="0.3" potential="harmonic" fractional_bondorder_method="None" fractional_bondorder_interpolation="linear">
+		<Bond smirks="[#6X4:1]-[#6X4:2]" length="1.520375903275 * angstrom" k="531.137373861 * angstrom**-2 * mole**-1 * kilocalorie" id="b1"></Bond>
+		<Bond smirks="[#6X4:1]-[#6X3:2]" length="1.503004231651 * angstrom" k="612.5097961064 * angstrom**-2 * mole**-1 * kilocalorie" id="b2"></Bond>
+		<Bond smirks="[#6X4:1]-[#6X3:2]=[#8X1+0]" length="1.521605984526 * angstrom" k="612.0537081219 * angstrom**-2 * mole**-1 * kilocalorie" id="b3"></Bond>
+		<Bond smirks="[#6X3:1]-[#6X3:2]" length="1.459752099251 * angstrom" k="568.1471787335 * angstrom**-2 * mole**-1 * kilocalorie" id="b4"></Bond>
+		<Bond smirks="[#6X3:1]:[#6X3:2]" length="1.388664968947 * angstrom" k="703.9196442458 * angstrom**-2 * mole**-1 * kilocalorie" id="b5"></Bond>
+		<Bond smirks="[#6X3:1]=[#6X3:2]" length="1.372337637107 * angstrom" k="857.1115548611 * angstrom**-2 * mole**-1 * kilocalorie" id="b6"></Bond>
+		<Bond smirks="[#6:1]-[#7:2]" length="1.465648155674 * angstrom" k="719.6326854584 * angstrom**-2 * mole**-1 * kilocalorie" id="b7"></Bond>
+		<Bond smirks="[#6X3:1]-[#7X3:2]" length="1.387166824415 * angstrom" k="719.219372554 * angstrom**-2 * mole**-1 * kilocalorie" id="b8"></Bond>
+		<Bond smirks="[#6X4:1]-[#7X3:2]-[#6X3]=[#8X1+0]" length="1.442186178076 * angstrom" k="764.7120801727 * angstrom**-2 * mole**-1 * kilocalorie" id="b9"></Bond>
+		<Bond smirks="[#6X3:1](=[#8X1+0])-[#7X3:2]" length="1.375176351196 * angstrom" k="1053.970761594 * angstrom**-2 * mole**-1 * kilocalorie" id="b10"></Bond>
+		<Bond smirks="[#6X3:1]-[#7X2:2]" length="1.374709480195 * angstrom" k="837.2647972972 * angstrom**-2 * mole**-1 * kilocalorie" id="b11"></Bond>
+		<Bond smirks="[#6X3:1]:[#7X2,#7X3+1:2]" length="1.325255477593 * angstrom" k="848.5474509553 * angstrom**-2 * mole**-1 * kilocalorie" id="b12"></Bond>
+		<Bond smirks="[#6X3:1]=[#7X2,#7X3+1:2]" length="1.315234804241 * angstrom" k="882.4191878243 * angstrom**-2 * mole**-1 * kilocalorie" id="b13"></Bond>
+		<Bond smirks="[#6:1]-[#8:2]" length="1.414287924481 * angstrom" k="669.1415170138 * angstrom**-2 * mole**-1 * kilocalorie" id="b14"></Bond>
+		<Bond smirks="[#6X4:1]-[#8X2H0:2]" length="1.426488233342 * angstrom" k="773.0316724808 * angstrom**-2 * mole**-1 * kilocalorie" id="b15"></Bond>
+		<Bond smirks="[#6X3:1]-[#8X2:2]" length="1.355290880386 * angstrom" k="636.8285821663 * angstrom**-2 * mole**-1 * kilocalorie" id="b16"></Bond>
+		<Bond smirks="[#6X3:1]-[#8X2H1:2]" length="1.367594686257 * angstrom" k="875.4107624763 * angstrom**-2 * mole**-1 * kilocalorie" id="b17"></Bond>
+		<Bond smirks="[#6X3a:1]-[#8X2H0:2]" length="1.386623123464 * angstrom" k="814.7919342234 * angstrom**-2 * mole**-1 * kilocalorie" id="b18"></Bond>
+		<Bond smirks="[#6X3:1](=[#8X1])-[#8X2H0:2]" length="1.338559054373 * angstrom" k="611.4736852721 * angstrom**-2 * mole**-1 * kilocalorie" id="b19"></Bond>
+		<Bond smirks="[#6:1]=[#8X1+0,#8X2+1:2]" length="1.22768286085 * angstrom" k="1135.595318618 * angstrom**-2 * mole**-1 * kilocalorie" id="b20"></Bond>
+		<Bond smirks="[#6X3:1](~[#8X1])~[#8X1:2]" length="1.259500720071 * angstrom" k="1226.156681261 * angstrom**-2 * mole**-1 * kilocalorie" id="b21"></Bond>
+		<Bond smirks="[#6X3:1]~[#8X2+1:2]~[#6X3]" length="1.339634537178 * angstrom" k="1121.691574284 * angstrom**-2 * mole**-1 * kilocalorie" id="b22"></Bond>
+		<Bond smirks="[#6X2:1]-[#6:2]" length="1.439319134757 * angstrom" k="729.6661176606 * angstrom**-2 * mole**-1 * kilocalorie" id="b23"></Bond>
+		<Bond smirks="[#6X2:1]-[#6X4:2]" length="1.452070257372 * angstrom" k="776.2033045699 * angstrom**-2 * mole**-1 * kilocalorie" id="b24"></Bond>
+		<Bond smirks="[#6X2:1]=[#6X3:2]" length="1.32265860193 * angstrom" k="1126.019190271 * angstrom**-2 * mole**-1 * kilocalorie" id="b25"></Bond>
+		<Bond smirks="[#6:1]#[#7:2]" length="1.173615721934 * angstrom" k="782.0438380706 * angstrom**-2 * mole**-1 * kilocalorie" id="b26"></Bond>
+		<Bond smirks="[#6X2:1]#[#6X2:2]" length="1.216289425279 * angstrom" k="728.7151236895 * angstrom**-2 * mole**-1 * kilocalorie" id="b27"></Bond>
+		<Bond smirks="[#6X2:1]-[#8X2:2]" length="1.338505557335 * angstrom" k="737.0214463026 * angstrom**-2 * mole**-1 * kilocalorie" id="b28"></Bond>
+		<Bond smirks="[#6X2:1]-[#7:2]" length="1.343265592592 * angstrom" k="926.2217362126 * angstrom**-2 * mole**-1 * kilocalorie" id="b29"></Bond>
+		<Bond smirks="[#6X2:1]=[#7:2]" length="1.19497018523 * angstrom" k="915.3902453154 * angstrom**-2 * mole**-1 * kilocalorie" id="b30"></Bond>
+		<Bond smirks="[#16:1]=[#6:2]" length="1.695948094419 * angstrom" k="606.5161612099 * angstrom**-2 * mole**-1 * kilocalorie" id="b31a"></Bond>
+		<Bond smirks="[#6X2:1]=[#16:2]" length="1.583084701849 * angstrom" k="874.5352668762 * angstrom**-2 * mole**-1 * kilocalorie" id="b31"></Bond>
+		<Bond smirks="[#7:1]-[#7:2]" length="1.456427148228 * angstrom" k="856.3884876222 * angstrom**-2 * mole**-1 * kilocalorie" id="b32"></Bond>
+		<Bond smirks="[#7X3:1]-[#7X2:2]" length="1.336997136683 * angstrom" k="721.2583300948 * angstrom**-2 * mole**-1 * kilocalorie" id="b33"></Bond>
+		<Bond smirks="[#7X2:1]-[#7X2:2]" length="1.334711243126 * angstrom" k="684.6186062369 * angstrom**-2 * mole**-1 * kilocalorie" id="b34"></Bond>
+		<Bond smirks="[#7:1]:[#7:2]" length="1.309910760379 * angstrom" k="698.9386390879 * angstrom**-2 * mole**-1 * kilocalorie" id="b35"></Bond>
+		<Bond smirks="[#7:1]=[#7:2]" length="1.258230502017 * angstrom" k="733.7063583316 * angstrom**-2 * mole**-1 * kilocalorie" id="b36"></Bond>
+		<Bond smirks="[#7:1]#[#7:2]" length="1.167045703639 * angstrom" k="768.2515008465 * angstrom**-2 * mole**-1 * kilocalorie" id="b37"></Bond>
+		<Bond smirks="[#7:1]-[#8X2:2]" length="1.427444600619 * angstrom" k="609.6331726762 * angstrom**-2 * mole**-1 * kilocalorie" id="b38"></Bond>
+		<Bond smirks="[#7:1]~[#8X1:2]" length="1.258536604727 * angstrom" k="804.2141054566 * angstrom**-2 * mole**-1 * kilocalorie" id="b39"></Bond>
+		<Bond smirks="[#8X2:1]-[#8X2:2]" length="1.446833791864 * angstrom" k="598.1110360445 * angstrom**-2 * mole**-1 * kilocalorie" id="b40"></Bond>
+		<Bond smirks="[#16:1]-[#6:2]" length="1.81 * angstrom" k="474.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b41"></Bond>
+		<Bond smirks="[#16:1]-[#1:2]" length="1.324549474701 * angstrom" k="583.3742749411 * angstrom**-2 * mole**-1 * kilocalorie" id="b42"></Bond>
+		<Bond smirks="[#16:1]-[#16:2]" length="2.081686035078 * angstrom" k="318.4060340666 * angstrom**-2 * mole**-1 * kilocalorie" id="b43"></Bond>
+		<Bond smirks="[#16:1]-[#9:2]" length="1.6 * angstrom" k="750.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b44"></Bond>
+		<Bond smirks="[#16:1]-[#17:2]" length="2.094110046685 * angstrom" k="419.5765860777 * angstrom**-2 * mole**-1 * kilocalorie" id="b45"></Bond>
+		<Bond smirks="[#16:1]-[#35:2]" length="2.237744050073 * angstrom" k="336.4025371784 * angstrom**-2 * mole**-1 * kilocalorie" id="b46"></Bond>
+		<Bond smirks="[#16:1]-[#53:2]" length="2.6 * angstrom" k="150.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b47"></Bond>
+		<Bond smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X4:2]" length="1.829210526082 * angstrom" k="415.2751791003 * angstrom**-2 * mole**-1 * kilocalorie" id="b48"></Bond>
+		<Bond smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]" length="1.762588405073 * angstrom" k="548.2622260123 * angstrom**-2 * mole**-1 * kilocalorie" id="b49"></Bond>
+		<Bond smirks="[#16X2:1]-[#7:2]" length="1.729944910038 * angstrom" k="626.0211477833 * angstrom**-2 * mole**-1 * kilocalorie" id="b50"></Bond>
+		<Bond smirks="[#16X2:1]-[#8X2:2]" length="1.674222096904 * angstrom" k="545.9813102907 * angstrom**-2 * mole**-1 * kilocalorie" id="b51"></Bond>
+		<Bond smirks="[#16X2:1]=[#8X1,#7X2:2]" length="1.492440425396 * angstrom" k="608.7780870561 * angstrom**-2 * mole**-1 * kilocalorie" id="b52"></Bond>
+		<Bond smirks="[#16X4,#16X3!+1:1]-[#6:2]" length="1.82526511478 * angstrom" k="490.9750761558 * angstrom**-2 * mole**-1 * kilocalorie" id="b53"></Bond>
+		<Bond smirks="[#16X4,#16X3:1]~[#7:2]" length="1.74923391533 * angstrom" k="532.2740756485 * angstrom**-2 * mole**-1 * kilocalorie" id="b54"></Bond>
+		<Bond smirks="[#16X4,#16X3:1]-[#8X2:2]" length="1.705021255726 * angstrom" k="586.8193418268 * angstrom**-2 * mole**-1 * kilocalorie" id="b55"></Bond>
+		<Bond smirks="[#16X4,#16X3:1]~[#8X1:2]" length="1.476709899089 * angstrom" k="988.5263278679 * angstrom**-2 * mole**-1 * kilocalorie" id="b56"></Bond>
+		<Bond smirks="[#15:1]-[#1:2]" length="1.425620548319 * angstrom" k="475.8196836784 * angstrom**-2 * mole**-1 * kilocalorie" id="b58"></Bond>
+		<Bond smirks="[#15:1]~[#6:2]" length="1.820098467465 * angstrom" k="334.797260159 * angstrom**-2 * mole**-1 * kilocalorie" id="b59"></Bond>
+		<Bond smirks="[#15:1]-[#7:2]" length="1.738963612742 * angstrom" k="649.438242264 * angstrom**-2 * mole**-1 * kilocalorie" id="b60"></Bond>
+		<Bond smirks="[#15:1]=[#7:2]" length="1.607645772515 * angstrom" k="813.0616253008 * angstrom**-2 * mole**-1 * kilocalorie" id="b61"></Bond>
+		<Bond smirks="[#15:1]~[#8X2:2]" length="1.629136766264 * angstrom" k="492.3953020799 * angstrom**-2 * mole**-1 * kilocalorie" id="b62"></Bond>
+		<Bond smirks="[#15:1]~[#8X1:2]" length="1.492571787842 * angstrom" k="1128.459872581 * angstrom**-2 * mole**-1 * kilocalorie" id="b63"></Bond>
+		<Bond smirks="[#16:1]-[#15:2]" length="2.132598077518 * angstrom" k="303.5029002242 * angstrom**-2 * mole**-1 * kilocalorie" id="b65"></Bond>
+		<Bond smirks="[#15:1]=[#16X1:2]" length="1.961822956943 * angstrom" k="463.9165708413 * angstrom**-2 * mole**-1 * kilocalorie" id="b66"></Bond>
+		<Bond smirks="[#6:1]-[#9:2]" length="1.357188255231 * angstrom" k="771.2895584699 * angstrom**-2 * mole**-1 * kilocalorie" id="b67"></Bond>
+		<Bond smirks="[#6X4:1]-[#9:2]" length="1.360066836665 * angstrom" k="739.1286982085 * angstrom**-2 * mole**-1 * kilocalorie" id="b68"></Bond>
+		<Bond smirks="[#6:1]-[#17:2]" length="1.755619464273 * angstrom" k="397.6612674232 * angstrom**-2 * mole**-1 * kilocalorie" id="b69"></Bond>
+		<Bond smirks="[#6X4:1]-[#17:2]" length="1.794826174177 * angstrom" k="415.5952215538 * angstrom**-2 * mole**-1 * kilocalorie" id="b70"></Bond>
+		<Bond smirks="[#6:1]-[#35:2]" length="1.8919521291 * angstrom" k="341.814550321 * angstrom**-2 * mole**-1 * kilocalorie" id="b71"></Bond>
+		<Bond smirks="[#6X4:1]-[#35:2]" length="1.962281793838 * angstrom" k="371.0571720485 * angstrom**-2 * mole**-1 * kilocalorie" id="b72"></Bond>
+		<Bond smirks="[#6:1]-[#53:2]" length="2.180863120343 * angstrom" k="345.9312229715 * angstrom**-2 * mole**-1 * kilocalorie" id="b73"></Bond>
+		<Bond smirks="[#6X4:1]-[#53:2]" length="2.166 * angstrom" k="296.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b74"></Bond>
+		<Bond smirks="[#7:1]-[#9:2]" length="1.437374377723 * angstrom" k="294.3868210844 * angstrom**-2 * mole**-1 * kilocalorie" id="b75"></Bond>
+		<Bond smirks="[#7:1]-[#17:2]" length="1.794539502537 * angstrom" k="294.602035553 * angstrom**-2 * mole**-1 * kilocalorie" id="b76"></Bond>
+		<Bond smirks="[#7:1]-[#35:2]" length="1.923890882292 * angstrom" k="203.8621603045 * angstrom**-2 * mole**-1 * kilocalorie" id="b77"></Bond>
+		<Bond smirks="[#7:1]-[#53:2]" length="2.1 * angstrom" k="160.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b78"></Bond>
+		<Bond smirks="[#15:1]-[#9:2]" length="1.64 * angstrom" k="880.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b79"></Bond>
+		<Bond smirks="[#15:1]-[#17:2]" length="2.040421255642 * angstrom" k="329.1717843591 * angstrom**-2 * mole**-1 * kilocalorie" id="b80"></Bond>
+		<Bond smirks="[#15:1]-[#35:2]" length="2.240634354523 * angstrom" k="249.9731712665 * angstrom**-2 * mole**-1 * kilocalorie" id="b81"></Bond>
+		<Bond smirks="[#15:1]-[#53:2]" length="2.6 * angstrom" k="140.0 * angstrom**-2 * mole**-1 * kilocalorie" id="b82"></Bond>
+		<Bond smirks="[#6X4:1]-[#1:2]" length="1.092888378383 * angstrom" k="758.0931772913 * angstrom**-2 * mole**-1 * kilocalorie" id="b83"></Bond>
+		<Bond smirks="[#6X3:1]-[#1:2]" length="1.08506612939 * angstrom" k="808.1394472833 * angstrom**-2 * mole**-1 * kilocalorie" id="b84"></Bond>
+		<Bond smirks="[#6X2:1]-[#1:2]" length="1.0675780086 * angstrom" k="886.8140078234 * angstrom**-2 * mole**-1 * kilocalorie" id="b85"></Bond>
+		<Bond smirks="[#7:1]-[#1:2]" length="1.021370282176 * angstrom" k="997.7547006218 * angstrom**-2 * mole**-1 * kilocalorie" id="b86"></Bond>
+		<Bond smirks="[#8:1]-[#1:2]" length="0.9707687589944 * angstrom" k="1120.583236119 * angstrom**-2 * mole**-1 * kilocalorie" id="b87"></Bond>
+	</Bonds>
+	<Angles version="0.3" potential="harmonic">
+		<Angle smirks="[*:1]~[#6X4:2]-[*:3]" angle="107.6607821752 * degree" k="101.7373362367 * mole**-1 * radian**-2 * kilocalorie" id="a1"></Angle>
+		<Angle smirks="[#1:1]-[#6X4:2]-[#1:3]" angle="107.5991506326 * degree" k="74.28701527177 * mole**-1 * radian**-2 * kilocalorie" id="a2"></Angle>
+		<Angle smirks="[*;r3:1]1~;@[*;r3:2]~;@[*;r3:3]1" angle="92.01151955292 * degree" k="236.4566893088 * mole**-1 * radian**-2 * kilocalorie" id="a3"></Angle>
+		<Angle smirks="[*;r3:1]~;@[*;r3:2]~;!@[*:3]" angle="118.6397680739 * degree" k="72.98541272684 * mole**-1 * radian**-2 * kilocalorie" id="a4"></Angle>
+		<Angle smirks="[*:1]~;!@[*;r3:2]~;!@[*:3]" angle="117.2796647982 * degree" k="134.6903763341 * mole**-1 * radian**-2 * kilocalorie" id="a5"></Angle>
+		<Angle smirks="[#1:1]-[*;r3:2]~;!@[*:3]" angle="113.9117551062 * degree" k="17.45745186093 * mole**-1 * radian**-2 * kilocalorie" id="a6"></Angle>
+		<Angle smirks="[#6r4:1]-;@[#6r4:2]-;@[#6r4:3]" angle="95.89600422195 * degree" k="173.3075144443 * mole**-1 * radian**-2 * kilocalorie" id="a7"></Angle>
+		<Angle smirks="[!#1:1]-[#6r4:2]-;!@[!#1:3]" angle="120.5855863277 * degree" k="66.79578563419 * mole**-1 * radian**-2 * kilocalorie" id="a8"></Angle>
+		<Angle smirks="[!#1:1]-[#6r4:2]-;!@[#1:3]" angle="115.3485773002 * degree" k="92.53584121506 * mole**-1 * radian**-2 * kilocalorie" id="a9"></Angle>
+		<Angle smirks="[*:1]~[#6X3:2]~[*:3]" angle="132.6611914923 * degree" k="153.5899485526 * mole**-1 * radian**-2 * kilocalorie" id="a10"></Angle>
+		<Angle smirks="[#1:1]-[#6X3:2]~[*:3]" angle="138.3188636899 * degree" k="66.86418192583 * mole**-1 * radian**-2 * kilocalorie" id="a11"></Angle>
+		<Angle smirks="[#1:1]-[#6X3:2]-[#1:3]" angle="129.8919606001 * degree" k="79.05881335449 * mole**-1 * radian**-2 * kilocalorie" id="a12"></Angle>
+		<Angle smirks="[*;r6:1]~;@[*;r5:2]~;@[*;r5;x2:3]" angle="129.6186355583 * degree" k="8.393092356008 * mole**-1 * radian**-2 * kilocalorie" id="a13"></Angle>
+		<Angle smirks="[*:1]~;!@[*;X3;r5:2]~;@[*;r5:3]" angle="134.7190008471 * degree" k="70.66802196994 * mole**-1 * radian**-2 * kilocalorie" id="a14"></Angle>
+		<Angle smirks="[#8X1:1]~[#6X3:2]~[#8:3]" angle="135.0017221622 * degree" k="228.4556274517 * mole**-1 * radian**-2 * kilocalorie" id="a15"></Angle>
+		<Angle smirks="[*:1]~[#6X2:2]~[*:3]" angle="180.0 * degree" k="141.066778699 * mole**-1 * radian**-2 * kilocalorie" id="a16"></Angle>
+		<Angle smirks="[*:1]~[#7X2:2]~[*:3]" angle="180.0 * degree" k="43.86782392711 * mole**-1 * radian**-2 * kilocalorie" id="a21"></Angle>
+		<Angle smirks="[*:1]-[#7X4,#7X3,#7X2-1:2]-[*:3]" angle="115.9143430445 * degree" k="148.6973378749 * mole**-1 * radian**-2 * kilocalorie" id="a17"></Angle>
+		<Angle smirks="[#1:1]-[#7X4,#7X3,#7X2-1:2]-[*:3]" angle="113.8216708315 * degree" k="84.12106400194 * mole**-1 * radian**-2 * kilocalorie" id="a18"></Angle>
+		<Angle smirks="[*:1]~[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]~[*:3]" angle="118.7733529574 * degree" k="112.545110149 * mole**-1 * radian**-2 * kilocalorie" id="a19"></Angle>
+		<Angle smirks="[#1:1]-[#7X3$(*~[#6X3,#6X2,#7X2+0]):2]-[*:3]" angle="122.0060844738 * degree" k="77.52610202633 * mole**-1 * radian**-2 * kilocalorie" id="a20"></Angle>
+		<Angle smirks="[*:1]~[#7X2+0:2]~[*:3]" angle="119.2677720132 * degree" k="226.9001499199 * mole**-1 * radian**-2 * kilocalorie" id="a22"></Angle>
+		<Angle smirks="[#1:1]-[#7X2+0:2]~[*:3]" angle="126.3683382039 * degree" k="122.0886574234 * mole**-1 * radian**-2 * kilocalorie" id="a23"></Angle>
+		<Angle smirks="[#6,#7,#8:1]-[#7X3:2](~[#8X1])~[#8X1:3]" angle="113.7330960918 * degree" k="222.9512331442 * mole**-1 * radian**-2 * kilocalorie" id="a24"></Angle>
+		<Angle smirks="[#8X1:1]~[#7X3:2]~[#8X1:3]" angle="129.0640146903 * degree" k="244.7497409824 * mole**-1 * radian**-2 * kilocalorie" id="a25"></Angle>
+		<Angle smirks="[*:1]~[#7X2:2]~[#7X1:3]" angle="180.0 * degree" k="85.78959792905 * mole**-1 * radian**-2 * kilocalorie" id="a26"></Angle>
+		<Angle smirks="[*:1]-[#8:2]-[*:3]" angle="110.2517797785 * degree" k="112.3648888241 * mole**-1 * radian**-2 * kilocalorie" id="a27"></Angle>
+		<Angle smirks="[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]" angle="113.749133441 * degree" k="198.6434920934 * mole**-1 * radian**-2 * kilocalorie" id="a28"></Angle>
+		<Angle smirks="[*:1]-[#8X2+1:2]=[*:3]" angle="120.6194234196 * degree" k="88.00391898891 * mole**-1 * radian**-2 * kilocalorie" id="a29"></Angle>
+		<Angle smirks="[*:1]~[#16X4:2]~[*:3]" angle="102.8533293826 * degree" k="203.9761892412 * mole**-1 * radian**-2 * kilocalorie" id="a30"></Angle>
+		<Angle smirks="[*:1]-[#16X4,#16X3+0:2]-[*:3]" angle="93.10273130442 * degree" k="148.5489471172 * mole**-1 * radian**-2 * kilocalorie" id="a31"></Angle>
+		<Angle smirks="[*:1]~[#16X3$(*~[#8X1,#7X2]):2]~[*:3]" angle="105.27918908 * degree" k="131.5701278604 * mole**-1 * radian**-2 * kilocalorie" id="a32"></Angle>
+		<Angle smirks="[*:1]~[#16X2,#16X3+1:2]~[*:3]" angle="102.5325123581 * degree" k="155.6608313033 * mole**-1 * radian**-2 * kilocalorie" id="a33"></Angle>
+		<Angle smirks="[*:1]=[#16X2:2]=[*:3]" angle="180.0 * degree" k="140.0 * mole**-1 * radian**-2 * kilocalorie" id="a34"></Angle>
+		<Angle smirks="[*:1]=[#16X2:2]=[#8:3]" angle="116.8957504594 * degree" k="135.0821099905 * mole**-1 * radian**-2 * kilocalorie" id="a34a"></Angle>
+		<Angle smirks="[#6X3:1]-[#16X2:2]-[#6X3:3]" angle="105.0921879973 * degree" k="189.8954666404 * mole**-1 * radian**-2 * kilocalorie" id="a35"></Angle>
+		<Angle smirks="[#6X3:1]-[#16X2:2]-[#6X4:3]" angle="94.39131484403 * degree" k="148.0197011788 * mole**-1 * radian**-2 * kilocalorie" id="a36"></Angle>
+		<Angle smirks="[#6X3:1]-[#16X2:2]-[#1:3]" angle="97.65567062192 * degree" k="114.2356380309 * mole**-1 * radian**-2 * kilocalorie" id="a37"></Angle>
+		<Angle smirks="[*:1]~[#15:2]~[*:3]" angle="121.7393987118 * degree" k="149.2087083994 * mole**-1 * radian**-2 * kilocalorie" id="a38"></Angle>
+	</Angles>
+	<ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))" default_idivf="auto">
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.2042684902198 * mole**-1 * kilocalorie" id="t1" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="0.0605419264413 * mole**-1 * kilocalorie" k2="0.4092110734344 * mole**-1 * kilocalorie" k3="0.4200425154529 * mole**-1 * kilocalorie" id="t2" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1044905747383 * mole**-1 * kilocalorie" id="t3" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" periodicity1="3" phase1="0.0 * degree" k1="0.106579031638 * mole**-1 * kilocalorie" id="t4" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X2:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="-0.2483367359288 * mole**-1 * kilocalorie" k2="1.128041608539 * mole**-1 * kilocalorie" id="t5" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#9:1]-[#6X4:2]-[#6X4:3]-[#9:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.09417224713276 * mole**-1 * kilocalorie" k2="0.411620155453 * mole**-1 * kilocalorie" id="t6" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#17:1]-[#6X4:2]-[#6X4:3]-[#17:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.1331743756595 * mole**-1 * kilocalorie" k2="-0.2268282090029 * mole**-1 * kilocalorie" id="t7" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#35:1]-[#6X4:2]-[#6X4:3]-[#35:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.03462841703189 * mole**-1 * kilocalorie" k2="-0.1922542771735 * mole**-1 * kilocalorie" id="t8" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.1758169817633 * mole**-1 * kilocalorie" k2="-0.4828571351304 * mole**-1 * kilocalorie" id="t9" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#9:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.1078167477482 * mole**-1 * kilocalorie" k2="0.3430106006498 * mole**-1 * kilocalorie" id="t10" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#17:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.3016855451662 * mole**-1 * kilocalorie" k2="0.1313715548727 * mole**-1 * kilocalorie" id="t11" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#35:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.2605683736706 * mole**-1 * kilocalorie" k2="0.973725680562 * mole**-1 * kilocalorie" id="t12" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X4;r3:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.007592301840152 * mole**-1 * kilocalorie" id="t13" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" phase1="0.0 * degree" k1="-0.08233024955265 * mole**-1 * kilocalorie" id="t14" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4;r3:2]-@[#6X4;r3:3]-[*:4]" periodicity1="2" phase1="0.0 * degree" k1="-1.353782897678 * mole**-1 * kilocalorie" id="t15" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-[#6X4;r3:2]-[#6X4;r3:3]-[*:4]" periodicity1="2" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="2.737380742685 * mole**-1 * kilocalorie" k2="3.956364290721 * mole**-1 * kilocalorie" id="t16" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#6X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1276594477369 * mole**-1 * kilocalorie" id="t17" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#6X3:3]=[*:4]" periodicity1="2" phase1="0.0 * degree" k1="-0.597427050072 * mole**-1 * kilocalorie" id="t20" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#8X1:4]" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="0.1789270699027 * mole**-1 * kilocalorie" k2="-0.04232792925765 * mole**-1 * kilocalorie" k3="-0.08746409932169 * mole**-1 * kilocalorie" id="t18" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" periodicity1="3" periodicity2="1" periodicity3="3" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="-0.1873119095899 * mole**-1 * kilocalorie" k2="-0.04978952830043 * mole**-1 * kilocalorie" k3="0.3463807083481 * mole**-1 * kilocalorie" id="t19" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.2131311610311 * mole**-1 * kilocalorie" k2="0.7627055695704 * mole**-1 * kilocalorie" id="t21" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#7X3:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" periodicity1="1" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="0.1824795050487 * mole**-1 * kilocalorie" k2="-0.3603670219594 * mole**-1 * kilocalorie" id="t22" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" periodicity1="4" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="-0.02052647057064 * mole**-1 * kilocalorie" k2="0.07928952716305 * mole**-1 * kilocalorie" id="t23" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#1:4]" periodicity1="2" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.1737641394184 * mole**-1 * kilocalorie" k2="-0.1890925901757 * mole**-1 * kilocalorie" id="t24" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X4,#7X3:4]" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="2" periodicity5="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" phase4="270.0 * degree" phase5="90.0 * degree" k1="0.1078089877718 * mole**-1 * kilocalorie" k2="0.09278468525422 * mole**-1 * kilocalorie" k3="0.9960488213521 * mole**-1 * kilocalorie" k4="0.260584803531 * mole**-1 * kilocalorie" k5="0.3136228873527 * mole**-1 * kilocalorie" id="t25" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0"></Proper>
+		<Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X3$(*-[#6X3,#6X2]):4]" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="2" periodicity5="1" periodicity6="1" phase1="270.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" phase4="270.0 * degree" phase5="270.0 * degree" phase6="0.0 * degree" k1="0.08033482806493 * mole**-1 * kilocalorie" k2="-0.137580576949 * mole**-1 * kilocalorie" k3="0.9946589743277 * mole**-1 * kilocalorie" k4="0.2268286377737 * mole**-1 * kilocalorie" k5="0.65219409882 * mole**-1 * kilocalorie" k6="-0.5193766160867 * mole**-1 * kilocalorie" id="t26" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0" idivf6="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4;r3:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.1415487720542 * mole**-1 * kilocalorie" id="t27" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.1518183405832 * mole**-1 * kilocalorie" k2="1.14870493759 * mole**-1 * kilocalorie" id="t28" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="3" periodicity3="2" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="-0.03897130741755 * mole**-1 * kilocalorie" k2="-0.333163577142 * mole**-1 * kilocalorie" k3="0.3412438908884 * mole**-1 * kilocalorie" id="t29" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]-[#7X3:4]" periodicity1="2" periodicity2="1" periodicity3="3" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="1.539412096516 * mole**-1 * kilocalorie" k2="0.5735548323954 * mole**-1 * kilocalorie" k3="0.8448125537749 * mole**-1 * kilocalorie" id="t30" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" periodicity2="1" periodicity3="3" phase1="180.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="3.301974551105 * mole**-1 * kilocalorie" k2="-0.07256453943771 * mole**-1 * kilocalorie" k3="0.04373598115894 * mole**-1 * kilocalorie" id="t31" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="2" phase1="180.0 * degree" k1="0.9065324693536 * mole**-1 * kilocalorie" id="t32" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.04786463196335 * mole**-1 * kilocalorie" k2="0.1047480522598 * mole**-1 * kilocalorie" id="t33" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" periodicity1="4" periodicity2="3" periodicity3="2" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="0.015950140458 * mole**-1 * kilocalorie" k2="-1.549773172362 * mole**-1 * kilocalorie" k3="0.4019718273629 * mole**-1 * kilocalorie" id="t34" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#6X3;r6:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.04348528649029 * mole**-1 * kilocalorie" k2="0.4549498533928 * mole**-1 * kilocalorie" id="t35" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]-;@[#6X3;r5:4]" periodicity1="4" periodicity2="3" periodicity3="2" phase1="180.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" k1="-0.06748672800029 * mole**-1 * kilocalorie" k2="0.4937784706757 * mole**-1 * kilocalorie" k3="0.6540665434676 * mole**-1 * kilocalorie" id="t36" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]=;@[#6X3;r5:4]" periodicity1="1" phase1="180.0 * degree" k1="0.2335458170782 * mole**-1 * kilocalorie" id="t37" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#6X4:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0841836475843 * mole**-1 * kilocalorie" id="t38" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#7X2;r6:4]" periodicity1="2" periodicity2="1" periodicity3="3" phase1="180.0 * degree" phase2="180.0 * degree" phase3="0.0 * degree" k1="2.23025149902 * mole**-1 * kilocalorie" k2="-0.4960340008049 * mole**-1 * kilocalorie" k3="0.6156959282373 * mole**-1 * kilocalorie" id="t39" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#7X2:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="0.4299264955005 * mole**-1 * kilocalorie" k2="0.6769651362667 * mole**-1 * kilocalorie" k3="0.3161458831389 * mole**-1 * kilocalorie" id="t40" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#8X2:4]" periodicity1="4" periodicity2="2" phase1="180.0 * degree" phase2="180.0 * degree" k1="-0.1813132690464 * mole**-1 * kilocalorie" k2="0.9258638279728 * mole**-1 * kilocalorie" id="t41" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" phase1="320.0 * degree" k1="-0.2715588257121 * mole**-1 * kilocalorie" id="t42" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.9155269008137 * mole**-1 * kilocalorie" id="t43" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]:[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.618818564799 * mole**-1 * kilocalorie" id="t44" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-,:[#6X3:2]=[#6X3:3]-,:[*:4]" periodicity1="2" phase1="180.0 * degree" k1="4.792759872377 * mole**-1 * kilocalorie" id="t45" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X3:2]=[#6X3:3]-[#6X4:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="180.0 * degree" k1="5.953289865563 * mole**-1 * kilocalorie" k2="1.072305796413 * mole**-1 * kilocalorie" id="t46" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#6X3$(*=[#8,#16,#7]):3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.7548786939088 * mole**-1 * kilocalorie" id="t47" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]=[#6X3:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" periodicity2="3" phase1="180.0 * degree" phase2="0.0 * degree" k1="0.7455769542514 * mole**-1 * kilocalorie" k2="0.6505987541733 * mole**-1 * kilocalorie" id="t48" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7a:2]:[#6a:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="4.593309631475 * mole**-1 * kilocalorie" id="t49" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1156981506898 * mole**-1 * kilocalorie" id="t50" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X3:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.2321691168976 * mole**-1 * kilocalorie" id="t51" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.3705879511091 * mole**-1 * kilocalorie" k2="-0.1341341034377 * mole**-1 * kilocalorie" id="t52" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.8749574048405 * mole**-1 * kilocalorie" id="t54" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="1" phase1="0.0 * degree" k1="1.008774405287 * mole**-1 * kilocalorie" id="t55" idivf1="1.0"></Proper>
+		<Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="-0.0766536570343 * mole**-1 * kilocalorie" id="t56" idivf1="1.0"></Proper>
+		<Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" phase1="0.0 * degree" k1="0.8774543263348 * mole**-1 * kilocalorie" id="t57" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X4:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="5.369347805632e-17 * mole**-1 * kilocalorie" id="t58" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" periodicity1="2" periodicity2="3" phase1="0.0 * degree" phase2="0.0 * degree" k1="-0.03305139926133 * mole**-1 * kilocalorie" k2="-0.05536205135587 * mole**-1 * kilocalorie" id="t59" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#8X1]):3]~[#8X1:4]" periodicity1="3" phase1="0.0 * degree" k1="8.47877793808e-18 * mole**-1 * kilocalorie" id="t60" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4:3]-[#6X3:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="0.0 * degree" k1="-0.5534139566497 * mole**-1 * kilocalorie" k2="-0.4613593740183 * mole**-1 * kilocalorie" id="t61" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]=[#8,#16,#7]" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="180.0 * degree" phase2="180.0 * degree" phase3="0.0 * degree" phase4="0.0 * degree" k1="-0.02939990984868 * mole**-1 * kilocalorie" k2="-0.131149297417 * mole**-1 * kilocalorie" k3="0.4462905163069 * mole**-1 * kilocalorie" k4="-0.5246679958425 * mole**-1 * kilocalorie" id="t62" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0"></Proper>
+		<Proper smirks="[#8X2H0:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]" periodicity1="2" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.006575461415428 * mole**-1 * kilocalorie" k2="2.5157095378 * mole**-1 * kilocalorie" id="t63" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.3445486734874 * mole**-1 * kilocalorie" k2="0.1649871217431 * mole**-1 * kilocalorie" k3="-1.195871309379 * mole**-1 * kilocalorie" id="t64" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2:2]-[#6X4:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-2.226456506206 * mole**-1 * kilocalorie" id="t65" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]=[#7X2,#7X3+1:2]-[#6X4:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.007272347748412 * mole**-1 * kilocalorie" id="t66" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]=[#7X2,#7X3+1:2]-[#6X4:3]-[#6X3,#6X4:4]" periodicity1="1" phase1="0.0 * degree" k1="1.115243623002 * mole**-1 * kilocalorie" id="t67" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3,#7X2-1:2]-[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.718745996216 * mole**-1 * kilocalorie" id="t68" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3,#7X2-1:2]-!@[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.037917001266 * mole**-1 * kilocalorie" id="t69" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X3:2]-[#6X3:3]=[#8,#16,#7:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="0.0 * degree" k1="2.346492420144 * mole**-1 * kilocalorie" k2="1.137927495861 * mole**-1 * kilocalorie" id="t70" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3;r5:2]-@[#6X3;r5:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.884040622793 * mole**-1 * kilocalorie" id="t71" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#7X3:2]~[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.464539201002 * mole**-1 * kilocalorie" id="t72" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#7X2,#7X3+1:2]-[#6X3:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.5024838332087 * mole**-1 * kilocalorie" id="t73" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#7X2,#7X3+1:2]-[#6X3:3]=,:[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.055700307947 * mole**-1 * kilocalorie" id="t74" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2,#7X3$(*~[#8X1]):2]:[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.949161231871 * mole**-1 * kilocalorie" id="t75" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]:[#7X2:2]:[#6X3:3]:[#6X3:4]" periodicity1="2" phase1="180.0 * degree" k1="5.12882020997 * mole**-1 * kilocalorie" id="t76" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-,:[#6X3:2]=[#7X2:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="6.38706963733 * mole**-1 * kilocalorie" id="t77" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3+1:2]=,:[#6X3:3]-,:[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.259904879645 * mole**-1 * kilocalorie" id="t78" idivf1="1.0"></Proper>
+		<Proper smirks="[#16X4,#16X3+0:1]-[#7X2:2]=[#6X3:3]-[#7X3:4]" periodicity1="2" phase1="180.0 * degree" k1="7.449362724034 * mole**-1 * kilocalorie" id="t79" idivf1="1.0"></Proper>
+		<Proper smirks="[#16X4,#16X3+0:1]-[#7X2:2]=[#6X3:3]-[#16X2,#16X3+1:4]" periodicity1="2" phase1="180.0 * degree" k1="7.44794573622 * mole**-1 * kilocalorie" id="t80" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X2:1]~[#7X2:2]-[#6X3:3]~[#6X3:4]" periodicity1="2" phase1="180.0 * degree" k1="0.7894608447333 * mole**-1 * kilocalorie" id="t81" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X2:1]~[#7X2:2]-[#6X4:3]-[#6X3:4]" periodicity1="2" phase1="0.0 * degree" k1="0.1682002924899 * mole**-1 * kilocalorie" id="t82" idivf1="1.0"></Proper>
+		<Proper smirks="[#7X2:1]~[#7X2:2]-[#6X4:3]~[#1:4]" periodicity1="2" phase1="0.0 * degree" k1="0.2066690085515 * mole**-1 * kilocalorie" id="t83" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#8X2:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.677754035886 * mole**-1 * kilocalorie" id="t84" idivf1="3.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H1:3]-[#1:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.6200339965628 * mole**-1 * kilocalorie" k2="0.1559715289248 * mole**-1 * kilocalorie" id="t85" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#6X4:2]-[#8X2H0:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.6487471201911 * mole**-1 * kilocalorie" id="t86" idivf1="3.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H0:3]-[#6X4:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.1201602570929 * mole**-1 * kilocalorie" k2="0.2551246630369 * mole**-1 * kilocalorie" id="t87" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2:3]-[#6X3:4]" periodicity1="3" periodicity2="1" phase1="0.0 * degree" phase2="180.0 * degree" k1="0.3142475958047 * mole**-1 * kilocalorie" k2="0.4833474029957 * mole**-1 * kilocalorie" id="t88" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#8X2:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="180.0 * degree" k1="0.3764539115662 * mole**-1 * kilocalorie" k2="0.1665998701278 * mole**-1 * kilocalorie" k3="1.002451174967 * mole**-1 * kilocalorie" id="t89" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#7X3:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.4733717929385 * mole**-1 * kilocalorie" k2="0.6188926485362 * mole**-1 * kilocalorie" id="t90" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#8X2:2]-[#6X4;r3:3]-@[#6X4;r3:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.2610240894789 * mole**-1 * kilocalorie" id="t91" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="0.143788943859 * mole**-1 * kilocalorie" id="t92" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.4318425069884 * mole**-1 * kilocalorie" k2="0.2319379326525 * mole**-1 * kilocalorie" k3="0.6296436621974 * mole**-1 * kilocalorie" id="t93" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.2849976154746 * mole**-1 * kilocalorie" k2="0.1292437806249 * mole**-1 * kilocalorie" k3="0.5311397361715 * mole**-1 * kilocalorie" id="t94" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4;r3:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.6634096149646 * mole**-1 * kilocalorie" k2="0.2633663955936 * mole**-1 * kilocalorie" k3="0.9542011283438 * mole**-1 * kilocalorie" id="t95" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#8X2:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.62929291652 * mole**-1 * kilocalorie" id="t96" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2]-[#8X2:3]-[#1:4]" periodicity1="2" phase1="180.0 * degree" k1="0.726205931984 * mole**-1 * kilocalorie" id="t97" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2](=[#8,#16,#7])-[#8X2H0:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.32811993543 * mole**-1 * kilocalorie" id="t98" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#6X3:2](=[#8,#16,#7])-[#8:3]-[#1:4]" periodicity1="2" phase1="180.0 * degree" k1="2.528228854647 * mole**-1 * kilocalorie" id="t99" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#8X2:2]-[#6X3:3]=[#8X1:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="0.0 * degree" k1="2.531229040642 * mole**-1 * kilocalorie" k2="1.828202607366 * mole**-1 * kilocalorie" id="t100" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#8,#16,#7:1]=[#6X3:2]-[#8X2H0:3]-[#6X4:4]" periodicity1="2" periodicity2="1" phase1="180.0 * degree" phase2="180.0 * degree" k1="1.625437483618 * mole**-1 * kilocalorie" k2="0.3820999993428 * mole**-1 * kilocalorie" id="t101" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2:2]@[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.435897161514 * mole**-1 * kilocalorie" id="t102" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2+1:2]=[#6X3:3]-[*:4]" periodicity1="2" phase1="180.0 * degree" k1="3.0 * mole**-1 * kilocalorie" id="t103" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#8X2+1:2]-[#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.4092140738685 * mole**-1 * kilocalorie" id="t104" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16:2]=,:[#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="3.592416344286 * mole**-1 * kilocalorie" id="t105" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.5219870587066 * mole**-1 * kilocalorie" id="t106" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#6:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1391610838139 * mole**-1 * kilocalorie" id="t107" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-@[#16X2,#16X1-1,#16X3+1:2]-@[#6X3,#7X2;r5:3]=@[#6,#7;r5:4]" periodicity1="2" phase1="180.0 * degree" k1="2.208938525658 * mole**-1 * kilocalorie" id="t108" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3!+1:2]-[#6X4:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.1136478469136 * mole**-1 * kilocalorie" id="t109" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#6X4:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.1387264656602 * mole**-1 * kilocalorie" id="t110" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#6X4:3]~[#6X4:4]" periodicity1="3" phase1="0.0 * degree" k1="0.5135725027276 * mole**-1 * kilocalorie" id="t111" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#6X3:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="0.3496146350028 * mole**-1 * kilocalorie" id="t112" idivf1="1.0"></Proper>
+		<Proper smirks="[#6:1]-[#16X4,#16X3+0:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.7795199683341 * mole**-1 * kilocalorie" id="t113" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#15:2]-[#6:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.002443571718831 * mole**-1 * kilocalorie" id="t114" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#15:2]-[#6X3:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.001992367425 * mole**-1 * kilocalorie" id="t115" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8:2]-[#8:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.5445220416871 * mole**-1 * kilocalorie" id="t116" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8:2]-[#8H1:3]-[*:4]" periodicity1="2" phase1="0.0 * degree" k1="0.3326104723068 * mole**-1 * kilocalorie" id="t117" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#8X2:2]-[#7:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.8307280524112 * mole**-1 * kilocalorie" id="t118" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2r5:2]-;@[#7X3r5:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.5286479506 * mole**-1 * kilocalorie" id="t119" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2r5:2]-;@[#7X2r5:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.05933872376973 * mole**-1 * kilocalorie" id="t120" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.8534757709034 * mole**-1 * kilocalorie" id="t121" idivf1="1.0"></Proper>
+		<Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.1975054585575 * mole**-1 * kilocalorie" k2="0.6241848836363 * mole**-1 * kilocalorie" k3="0.2694152338654 * mole**-1 * kilocalorie" id="t122" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.4212085878484 * mole**-1 * kilocalorie" k2="0.8879036298101 * mole**-1 * kilocalorie" k3="0.688629271769 * mole**-1 * kilocalorie" id="t123" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.8335579151882 * mole**-1 * kilocalorie" k2="1.129486608751 * mole**-1 * kilocalorie" k3="2.143594528019 * mole**-1 * kilocalorie" id="t124" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X4,#7X3:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.03344675530247 * mole**-1 * kilocalorie" id="t125" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3$(*-[#6X3,#6X2]):2]-[#7X3$(*-[#6X3,#6X2]):3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.1391875487532 * mole**-1 * kilocalorie" id="t126" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7X3$(*-[#6X3,#6X2])r5:2]-@[#7X3$(*-[#6X3,#6X2])r5:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="-1.065249127933 * mole**-1 * kilocalorie" id="t127" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]@[#7X2:2]@[#7X2:3]@[#7X2,#6X3:4]" periodicity1="1" phase1="180.0 * degree" k1="0.2079570107704 * mole**-1 * kilocalorie" id="t128a" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2:2]-[#7X3:3]~[*:4]" periodicity1="1" phase1="180.0 * degree" k1="0.8514968744526 * mole**-1 * kilocalorie" id="t128" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]=[#7X2:2]-[#7X2:3]=[*:4]" periodicity1="1" phase1="180.0 * degree" k1="1.499767373996 * mole**-1 * kilocalorie" id="t129" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X2:2]=,:[#7X2:3]~[*:4]" periodicity1="1" phase1="180.0 * degree" k1="6.47740768168 * mole**-1 * kilocalorie" id="t130" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3+1:2]=,:[#7X2:3]~[*:4]" periodicity1="1" phase1="180.0 * degree" k1="3.0 * mole**-1 * kilocalorie" id="t131" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[!#6:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="-0.2333557358222 * mole**-1 * kilocalorie" id="t133" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#7:3]~[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.51152804307 * mole**-1 * kilocalorie" id="t134" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="1" phase1="0.0 * degree" k1="-1.514362492777 * mole**-1 * kilocalorie" id="t135" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="3" phase1="0.0 * degree" k1="0.4279493895898 * mole**-1 * kilocalorie" id="t136" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="1" periodicity2="3" phase1="0.0 * degree" phase2="0.0 * degree" k1="0.5598961487159 * mole**-1 * kilocalorie" k2="0.6590735051956 * mole**-1 * kilocalorie" id="t137" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="0.3026942933012 * mole**-1 * kilocalorie" k2="1.198096905238 * mole**-1 * kilocalorie" k3="1.209851551226 * mole**-1 * kilocalorie" id="t138" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" periodicity1="1" periodicity2="3" phase1="180.0 * degree" phase2="0.0 * degree" k1="-0.56371143888 * mole**-1 * kilocalorie" k2="0.2537982014446 * mole**-1 * kilocalorie" id="t139" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="180.0 * degree" phase3="0.0 * degree" k1="0.2448981098593 * mole**-1 * kilocalorie" k2="0.3432197880948 * mole**-1 * kilocalorie" k3="1.920309966993 * mole**-1 * kilocalorie" id="t140" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" k1="1.155444592591 * mole**-1 * kilocalorie" k2="1.61687424291 * mole**-1 * kilocalorie" k3="1.356197352471 * mole**-1 * kilocalorie" id="t141" idivf1="1.0" idivf2="1.0" idivf3="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" periodicity1="3" periodicity2="2" phase1="90.0 * degree" phase2="0.0 * degree" k1="0.1346125288073 * mole**-1 * kilocalorie" k2="1.010013299443 * mole**-1 * kilocalorie" id="t142" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" periodicity1="1" phase1="0.0 * degree" k1="1.040012168564 * mole**-1 * kilocalorie" id="t143" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X3:3]-[#7X2:4]" periodicity1="1" phase1="0.0 * degree" k1="1.138731061568 * mole**-1 * kilocalorie" id="t144" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]=,:[#7X2:3]-,:[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.6019943654949 * mole**-1 * kilocalorie" id="t145" idivf1="1.0"></Proper>
+		<Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" periodicity1="6" periodicity2="5" periodicity3="4" periodicity4="3" periodicity5="2" periodicity6="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="0.0 * degree" phase4="0.0 * degree" phase5="180.0 * degree" phase6="0.0 * degree" k1="-0.04771589627733 * mole**-1 * kilocalorie" k2="0.8282851806511 * mole**-1 * kilocalorie" k3="0.01204072937984 * mole**-1 * kilocalorie" k4="0.7629247804472 * mole**-1 * kilocalorie" k5="2.66836500636 * mole**-1 * kilocalorie" k6="1.252206277842 * mole**-1 * kilocalorie" id="t146" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0" idivf6="1.0"></Proper>
+		<Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" periodicity1="6" periodicity2="5" periodicity3="4" periodicity4="2" periodicity5="3" periodicity6="1" phase1="0.0 * degree" phase2="0.0 * degree" phase3="180.0 * degree" phase4="180.0 * degree" phase5="180.0 * degree" phase6="0.0 * degree" k1="-0.2168186798692 * mole**-1 * kilocalorie" k2="1.10833542158 * mole**-1 * kilocalorie" k3="0.4467277261519 * mole**-1 * kilocalorie" k4="2.411074166888 * mole**-1 * kilocalorie" k5="0.8261849640204 * mole**-1 * kilocalorie" k6="2.207300781718 * mole**-1 * kilocalorie" id="t147" idivf1="1.0" idivf2="1.0" idivf3="1.0" idivf4="1.0" idivf5="1.0" idivf6="1.0"></Proper>
+		<Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#8X2:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="1.345814498131 * mole**-1 * kilocalorie" id="t148" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#16X2,#16X3+1:3]-[*:4]" periodicity1="2" periodicity2="3" phase1="0.0 * degree" phase2="0.0 * degree" k1="3.529263293178 * mole**-1 * kilocalorie" k2="0.5690320037338 * mole**-1 * kilocalorie" id="t149" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]-[#8X2:2]-[#15:3]~[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.796737659009 * mole**-1 * kilocalorie" id="t150" idivf1="1.0"></Proper>
+		<Proper smirks="[#8X2:1]-[#15:2]-[#8X2:3]-[#6X4:4]" periodicity1="3" periodicity2="2" phase1="0.0 * degree" phase2="0.0 * degree" k1="-1.041801197636 * mole**-1 * kilocalorie" k2="-1.125332211858 * mole**-1 * kilocalorie" id="t151" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7X3:2]-[#15:3]~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="2.248880120783 * mole**-1 * kilocalorie" id="t152" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[#7:2]-[#15:3]=[*:4]" periodicity1="2" periodicity2="3" phase1="180.0 * degree" phase2="0.0 * degree" k1="3.422374057462 * mole**-1 * kilocalorie" k2="0.8329784989581 * mole**-1 * kilocalorie" id="t154" idivf1="1.0" idivf2="1.0"></Proper>
+		<Proper smirks="[#6X3:1]-[#7:2]-[#15:3]=[*:4]" periodicity1="1" phase1="0.0 * degree" k1="-0.4293930381085 * mole**-1 * kilocalorie" id="t155" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[#7:2]=[#15:3]~[*:4]" periodicity1="3" phase1="0.0 * degree" k1="0.3307367671149 * mole**-1 * kilocalorie" id="t155b" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]-[*:2]#[*:3]-[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0 * mole**-1 * kilocalorie" id="t156" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[*:2]-[*:3]#[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0 * mole**-1 * kilocalorie" id="t157" idivf1="1.0"></Proper>
+		<Proper smirks="[*:1]~[*:2]=[#6,#7,#16,#15;X2:3]=[*:4]" periodicity1="1" phase1="0.0 * degree" k1="0.0 * mole**-1 * kilocalorie" id="t158" idivf1="1.0"></Proper>
+	</ProperTorsions>
+	<ImproperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))" default_idivf="auto">
+		<Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.1 * mole**-1 * kilocalorie" id="i1"></Improper>
+		<Improper smirks="[*:1]~[#6X3:2](~[#8X1:3])~[#8:4]" periodicity1="2" phase1="180.0 * degree" k1="10.5 * mole**-1 * kilocalorie" id="i2"></Improper>
+		<Improper smirks="[*:1]~[#7X3$(*~[#6X3]):2](~[*:3])~[*:4]" periodicity1="2" phase1="180.0 * degree" k1="1.0 * mole**-1 * kilocalorie" id="i3"></Improper>
+		<Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" periodicity1="2" phase1="180.0 * degree" k1="10.5 * mole**-1 * kilocalorie" id="i4"></Improper>
+	</ImproperTorsions>
+	<vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom" switch_width="1.0 * angstrom" method="cutoff">
+		<Atom smirks="[#1:1]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n1" rmin_half="0.6 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n2" rmin_half="1.487 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4]-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n3" rmin_half="1.387 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4](-[#7,#8,#9,#16,#17,#35])-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n4" rmin_half="1.287 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4](-[#7,#8,#9,#16,#17,#35])(-[#7,#8,#9,#16,#17,#35])-[#7,#8,#9,#16,#17,#35]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n5" rmin_half="1.187 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X4]~[*+1,*+2]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n6" rmin_half="1.1 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X3]" epsilon="0.015 * mole**-1 * kilocalorie" id="n7" rmin_half="1.459 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X3]~[#7,#8,#9,#16,#17,#35]" epsilon="0.015 * mole**-1 * kilocalorie" id="n8" rmin_half="1.409 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X3](~[#7,#8,#9,#16,#17,#35])~[#7,#8,#9,#16,#17,#35]" epsilon="0.015 * mole**-1 * kilocalorie" id="n9" rmin_half="1.359 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#6X2]" epsilon="0.015 * mole**-1 * kilocalorie" id="n10" rmin_half="1.459 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#7]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n11" rmin_half="0.6 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#8]" epsilon="5.27e-05 * mole**-1 * kilocalorie" id="n12" rmin_half="0.3 * angstrom"></Atom>
+		<Atom smirks="[#1:1]-[#16]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n13" rmin_half="0.6 * angstrom"></Atom>
+		<Atom smirks="[#6:1]" epsilon="0.086 * mole**-1 * kilocalorie" id="n14" rmin_half="1.908 * angstrom"></Atom>
+		<Atom smirks="[#6X2:1]" epsilon="0.21 * mole**-1 * kilocalorie" id="n15" rmin_half="1.908 * angstrom"></Atom>
+		<Atom smirks="[#6X4:1]" epsilon="0.1094 * mole**-1 * kilocalorie" id="n16" rmin_half="1.908 * angstrom"></Atom>
+		<Atom smirks="[#8:1]" epsilon="0.21 * mole**-1 * kilocalorie" id="n17" rmin_half="1.6612 * angstrom"></Atom>
+		<Atom smirks="[#8X2H0+0:1]" epsilon="0.17 * mole**-1 * kilocalorie" id="n18" rmin_half="1.6837 * angstrom"></Atom>
+		<Atom smirks="[#8X2H1+0:1]" epsilon="0.2104 * mole**-1 * kilocalorie" id="n19" rmin_half="1.721 * angstrom"></Atom>
+		<Atom smirks="[#7:1]" epsilon="0.17 * mole**-1 * kilocalorie" id="n20" rmin_half="1.824 * angstrom"></Atom>
+		<Atom smirks="[#16:1]" epsilon="0.25 * mole**-1 * kilocalorie" id="n21" rmin_half="2.0 * angstrom"></Atom>
+		<Atom smirks="[#15:1]" epsilon="0.2 * mole**-1 * kilocalorie" id="n22" rmin_half="2.1 * angstrom"></Atom>
+		<Atom smirks="[#9:1]" epsilon="0.061 * mole**-1 * kilocalorie" id="n23" rmin_half="1.75 * angstrom"></Atom>
+		<Atom smirks="[#17:1]" epsilon="0.265 * mole**-1 * kilocalorie" id="n24" rmin_half="1.948 * angstrom"></Atom>
+		<Atom smirks="[#35:1]" epsilon="0.32 * mole**-1 * kilocalorie" id="n25" rmin_half="2.22 * angstrom"></Atom>
+		<Atom smirks="[#53:1]" epsilon="0.4 * mole**-1 * kilocalorie" id="n26" rmin_half="2.35 * angstrom"></Atom>
+		<Atom smirks="[#3+1:1]" epsilon="0.0279896 * mole**-1 * kilocalorie" id="n27" rmin_half="1.025 * angstrom"></Atom>
+		<Atom smirks="[#11+1:1]" epsilon="0.0874393 * mole**-1 * kilocalorie" id="n28" rmin_half="1.369 * angstrom"></Atom>
+		<Atom smirks="[#19+1:1]" epsilon="0.1936829 * mole**-1 * kilocalorie" id="n29" rmin_half="1.705 * angstrom"></Atom>
+		<Atom smirks="[#37+1:1]" epsilon="0.3278219 * mole**-1 * kilocalorie" id="n30" rmin_half="1.813 * angstrom"></Atom>
+		<Atom smirks="[#55+1:1]" epsilon="0.4065394 * mole**-1 * kilocalorie" id="n31" rmin_half="1.976 * angstrom"></Atom>
+		<Atom smirks="[#9X0-1:1]" epsilon="0.003364 * mole**-1 * kilocalorie" id="n32" rmin_half="2.303 * angstrom"></Atom>
+		<Atom smirks="[#17X0-1:1]" epsilon="0.035591 * mole**-1 * kilocalorie" id="n33" rmin_half="2.513 * angstrom"></Atom>
+		<Atom smirks="[#35X0-1:1]" epsilon="0.0586554 * mole**-1 * kilocalorie" id="n34" rmin_half="2.608 * angstrom"></Atom>
+		<Atom smirks="[#53X0-1:1]" epsilon="0.0536816 * mole**-1 * kilocalorie" id="n35" rmin_half="2.86 * angstrom"></Atom>
+	</vdW>
+	<Electrostatics version="0.3" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" cutoff="9.0 * angstrom" switch_width="0.0 * angstrom" method="PME"></Electrostatics>
+    <LibraryCharges version="0.3">
+        <LibraryCharge name="Li+" smirks="[#3+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="Na+" smirks="[#11+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="K+" smirks="[#19+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="Rb+" smirks="[#37+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="Cs+" smirks="[#55+1:1]" charge1="1.0*elementary_charge"/>
+        <LibraryCharge name="F-" smirks="[#9X0-1:1]" charge1="-1.0*elementary_charge"/>
+        <LibraryCharge name="Cl-" smirks="[#17X0-1:1]" charge1="-1.0*elementary_charge"/>
+        <LibraryCharge name="Br-" smirks="[#35X0-1:1]" charge1="-1.0*elementary_charge"/>
+        <LibraryCharge name="I-" smirks="[#53X0-1:1]" charge1="-1.0*elementary_charge"/>
+    </LibraryCharges>
+	<ToolkitAM1BCC version="0.3"></ToolkitAM1BCC>
+</SMIRNOFF>


### PR DESCRIPTION
This addresses #5.

I have added the monatomic ion `LibraryCharges` added in openforcefield/openforcefield#563 in `openff-1.0.1.offxml`. I have also added appropriate entries under *Versions* in the README, and attempted to give a tree-like structure showing our version history.

There is another PR like this for adding monatomic ion `LibraryCharges` in `openff-1.1.1.offxml`: #10 