### PR TITLE
Add coverage canary tests

### DIFF
--- a/canary/README.md
+++ b/canary/README.md
@@ -16,7 +16,7 @@ pytest -v openforcefields/tests/
 
 ### Data sources
 
-* `data/coverage.smi`: Seeded from [here](https://raw.githubusercontent.com/openforcefield/open-forcefield-data/master/Utilize-All-Parameters/selected/chosen.smi). Molecules that do not type and/or fail with `openff-1.3.0` were commented out (10/26/20).
+* `data/coverage.smi`: Seeded from [here](https://raw.githubusercontent.com/openforcefield/open-forcefield-data/master/Utilize-All-Parameters/selected/chosen.smi). Molecules that do not type and/or fail with `openff-1.3.0` were commented out (10/26/20 and 10/27/20, see PR #27).
 * `data/propynes.smi`: Curated from [reported HMR failure](https://github.com/openforcefield/openforcefields/issues/19)
 
 ### Scripts

--- a/canary/README.md
+++ b/canary/README.md
@@ -16,7 +16,7 @@ pytest -v openforcefields/tests/
 
 ### Data sources
 
-* `data/coverage.smi`: Seeded from [here](https://raw.githubusercontent.com/openforcefield/open-forcefield-data/master/Utilize-All-Parameters/selected/chosen.smi)
+* `data/coverage.smi`: Seeded from [here](https://raw.githubusercontent.com/openforcefield/open-forcefield-data/master/Utilize-All-Parameters/selected/chosen.smi). Molecules that do not type and/or fail with `openff-1.3.0` were commented out (10/26/20).
 * `data/propynes.smi`: Curated from [reported HMR failure](https://github.com/openforcefield/openforcefields/issues/19)
 
 ### Scripts

--- a/canary/data/coverage.smi
+++ b/canary/data/coverage.smi
@@ -63,9 +63,9 @@ C[n+]1ccc(cc1)C(=O)N
 CC1(CC1(C(=O)N)C(=O)O)C
 # c1cc(nc(c1N(=O)O)N)Cl
 COP(=O)(NC(=O)C(Cl)(Cl)Cl)OC
-c1ccc(c(c1)S(=O)(=O)N=N#N)S(=O)(=O)N=N#N
+# c1ccc(c(c1)S(=O)(=O)N=N#N)S(=O)(=O)N=N#N
 Cn1cccc1C(=S)N=P(N(C)C)(N(C)C)N(C)C
 c1ccc(cc1)S(=O)(=O)N(F)S(=O)(=O)c2ccccc2
-c1ccc(cc1)P(c2ccccc2)(c3ccccc3)(I)I
-c1ccc(cc1)CP(Cc2cccc(c2)F)(c3ccccc3)(c4ccccc4)Br
+# c1ccc(cc1)P(c2ccccc2)(c3ccccc3)(I)I
+# c1ccc(cc1)CP(Cc2cccc(c2)F)(c3ccccc3)(c4ccccc4)Br
 c1cc(ccc1c2ccc(cc2)OSOc3ccc(cc3)Cl)OSOc4ccc(cc4)Cl

--- a/canary/data/coverage.smi
+++ b/canary/data/coverage.smi
@@ -31,7 +31,7 @@ CC(=C)C1(CC1)CON
 COC(=O)Cc1cs/c(=N/S(=O)(=O)C)/[nH]1
 C1CC1NC(=O)CN2CC(CO2)O
 CCC1CC1(c2ccc(nn2)OC)N
-CO/N=[N+](/C(Br)Br)\[O-]
+# CO/N=[N+](/C(Br)Br)\[O-]
 CC(=O)[O-]
 CS(=O)Cl
 C(C(F)(Cl)Br)(F)(F)Br
@@ -47,11 +47,11 @@ CCc1ccc(cc1)N=S=O
 CC(c1[nH][nH]c(=O)n1)NC#N
 CCS(=O)(=O)n1cc(cn1)O
 c1cc(ccc1OC2CC2)I
-c1ccc(cc1)S(F)(F)(F)(F)F
+# c1ccc(cc1)S(F)(F)(F)(F)F
 CCC(CCl)Cl
 CC(=O)c1ccc(cc1)S(=C)(=C)C
 COc1ccc(cc1OC)c2ccc3ccccc3[o+]2
-F[P-](F)(F)(F)(F)F
+# F[P-](F)(F)(F)(F)F
 CC(C)S(=O)(=O)Br
 C1CC(=O)N(C1=O)Br
 C=C=CN1CCCC1=O
@@ -61,7 +61,7 @@ CC(=O)OC#COC(=O)C
 C1[C@@H]2[C@@H]([C@H]2O)CN1
 C[n+]1ccc(cc1)C(=O)N
 CC1(CC1(C(=O)N)C(=O)O)C
-c1cc(nc(c1N(=O)O)N)Cl
+# c1cc(nc(c1N(=O)O)N)Cl
 COP(=O)(NC(=O)C(Cl)(Cl)Cl)OC
 c1ccc(c(c1)S(=O)(=O)N=N#N)S(=O)(=O)N=N#N
 Cn1cccc1C(=S)N=P(N(C)C)(N(C)C)N(C)C

--- a/canary/scripts/test_hmr.py
+++ b/canary/scripts/test_hmr.py
@@ -96,8 +96,6 @@ if __name__ == "__main__":
             file_format="smi",
             allow_undefined_stereo=True,
         )
-        # TODO: Add coverage set, with known failures stripped out
-        # hmr_mols = Molecule.from_file(str(coverage_mols), file_format='smi', allow_undefined_stereo=True)
         for mol in hmr_mols:
             try:
                 hmr_driver(mol, ff_name)

--- a/canary/scripts/test_hmr.py
+++ b/canary/scripts/test_hmr.py
@@ -21,6 +21,14 @@ class NANEnergyError(Exception):
 class CanaryError(Exception):
     """Base exception for canary"""
 
+    def __init__(self, message, runs):
+        super(CanaryError, self).__init__(message)
+        self.message = message
+        self.runs = runs
+
+    def __str__(self):
+        return self.message + "\n" + "\n".join(["\t".join(run) for run in self.runs])
+
 
 class HMRCanaryError(CanaryError):
     """Exception for an HMR canary test failing"""
@@ -78,7 +86,15 @@ if __name__ == "__main__":
         ff_name = line.split("/")[-1][:-8]
         # Molecule.from_file fails on pathlib.Path ojects, despite being str-like
         hmr_mols = Molecule.from_file(
-            str(propyne_mols), file_format="smi", allow_undefined_stereo=True
+            str(propyne_mols),
+            file_format="smi",
+            allow_undefined_stereo=True,
+        )
+        # Append coverage set, with known failures stripped out
+        hmr_mols += Molecule.from_file(
+            str(coverage_mols),
+            file_format="smi",
+            allow_undefined_stereo=True,
         )
         # TODO: Add coverage set, with known failures stripped out
         # hmr_mols = Molecule.from_file(str(coverage_mols), file_format='smi', allow_undefined_stereo=True)
@@ -86,12 +102,12 @@ if __name__ == "__main__":
             try:
                 hmr_driver(mol, ff_name)
             except NANEnergyError:
-                failed_runs.append([mol, ff_name, "NaN energy"])
+                failed_runs.append([mol.to_smiles(), ff_name, "NaN energy"])
             except Exception:
                 # OpenMM's OpenMMException cannot be caught as it does not
                 # inherit from BaseException; therefore this clause may
                 # hit other errors than NaN positions
-                failed_runs.append([mol, ff_name, "NaN position(s)"])
+                failed_runs.append([mol.to_smiles(), ff_name, "NaN position(s)"])
 
     if len(failed_runs) > 0:
-        raise HMRCanaryError(failed_runs)
+        raise HMRCanaryError("HMR tests failed:", failed_runs)


### PR DESCRIPTION
Round 2 of #21 

This just takes the list of SMILES and runs it through the existing HMR function. A cheaper approach would be to type a larger coverage set without running them through HMR. At some point, implementing https://github.com/openforcefield/openforcefield/issues/748 could make this even quicker via bypassing OpenMM.